### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test CyborgDB JavaScript SDK
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-js/security/code-scanning/3](https://github.com/cyborginc/cyborgdb-js/security/code-scanning/3)

To fix this issue, you should add an explicit `permissions` block to the workflow file, at either the workflow root level (to apply to all jobs) or at the job level (per job). Since the workflow involves checking out code and using basic actions, the safest minimal permission is usually `contents: read`. This allows the workflow to check out code and read from the repository, but not write or manage other repository resources. If a job requires additional permissions in the future, you can expand its job-level `permissions` block, but for now, `contents: read` suffices.

Specifically, you should add the following block after the `name:` declaration and before the `on:` trigger in `.github/workflows/test.yml`:

```yaml
permissions:
  contents: read
```

No additional dependencies or code changes are needed; just this change in the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
