### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_and_package_module.yml
+++ b/.github/workflows/test_and_package_module.yml
@@ -57,6 +57,8 @@ jobs:
           "
 
   build_package:
+    permissions:
+      contents: read
     needs: test_package
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-js/security/code-scanning/4](https://github.com/cyborginc/cyborgdb-js/security/code-scanning/4)

To fix the issue, update the `build_package` job in `.github/workflows/test_and_package_module.yml` to explicitly specify a minimal `permissions` block, thus restricting the `GITHUB_TOKEN` available to this job. This is best added directly under the job name (`build_package:`) and before `needs:` or `runs-on:`.  
- **What to change:** Add:
  ```yaml
    permissions:
      contents: read
  ```
  as the second line of the `build_package` job definition (just after `build_package:`).
- **Lines/region to change:** Insert after line `59:   build_package:`.
- **No other changes** are needed (no imports, methods, or variable definitions required for this YAML-level security change).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
