### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_and_package_module.yml
+++ b/.github/workflows/test_and_package_module.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test_package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/cyborginc/cyborgdb-js/security/code-scanning/2](https://github.com/cyborginc/cyborgdb-js/security/code-scanning/2)

To fix the problem, an explicit minimal `permissions` block should be added to the `test_package` job in the `.github/workflows/test_and_package_module.yml` file. Since this job is only running tests/builds and not modifying contents or PRs, the recommended block is `permissions: contents: read`. This change should be made immediately after the `runs-on: ubuntu-latest` line (`line 10`), before the `steps:` block begins. No imports, method definitions, or further configuration changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
