### PR TITLE
distance fixed in tests. dependency fixes.

### DIFF
--- a/.github/workflows/actions/codeartifact-pip-url/action.yml
+++ b/.github/workflows/actions/codeartifact-pip-url/action.yml
@@ -1,0 +1,61 @@
+name: CodeArtifact pip index URL
+description: Assume an AWS role via OIDC, fetch a CodeArtifact authorization token, and emit a pip index URL with the token embedded.
+
+inputs:
+  aws-account-id:
+    description: AWS account ID that owns the CodeArtifact domain.
+    required: true
+  role-to-assume:
+    description: IAM role ARN to assume via GitHub OIDC.
+    required: true
+  codeartifact-repository:
+    description: CodeArtifact repository name (e.g. cyborg-dev, cyborg-staging).
+    required: true
+  aws-region:
+    description: AWS region hosting the CodeArtifact domain.
+    required: false
+    default: us-east-1
+  codeartifact-domain:
+    description: CodeArtifact domain name.
+    required: false
+    default: cyborg
+  aws-cli-command:
+    description: Path to the aws CLI binary. Override when the binary isn't on PATH (e.g. on GitHub's GPU-powered runners).
+    required: false
+    default: aws
+
+outputs:
+  pip-index-url:
+    description: pip index URL with CodeArtifact auth token embedded. Masked in logs.
+    value: ${{ steps.build-url.outputs.pip-index-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Fetch CodeArtifact token and build pip index URL
+      id: build-url
+      shell: bash
+      env:
+        CA_DOMAIN: ${{ inputs.codeartifact-domain }}
+        CA_OWNER: ${{ inputs.aws-account-id }}
+        CA_REGION: ${{ inputs.aws-region }}
+        CA_REPO: ${{ inputs.codeartifact-repository }}
+        AWS_CLI: ${{ inputs.aws-cli-command }}
+      run: |
+        set -euo pipefail
+        TOKEN=$("$AWS_CLI" codeartifact get-authorization-token \
+          --domain "$CA_DOMAIN" \
+          --domain-owner "$CA_OWNER" \
+          --region "$CA_REGION" \
+          --query authorizationToken \
+          --output text)
+        echo "::add-mask::$TOKEN"
+        URL="https://aws:${TOKEN}@${CA_DOMAIN}-${CA_OWNER}.d.codeartifact.${CA_REGION}.amazonaws.com/pypi/${CA_REPO}/simple/"
+        echo "::add-mask::$URL"
+        echo "pip-index-url=$URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -57,6 +57,7 @@ jobs:
     needs: [lint, compute_version]
     permissions:
       contents: read
+      id-token: write
 
     services:
       postgres:
@@ -98,14 +99,27 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TOKEN }}
           CYBORGDB_API_KEY: "op://CyborgDB/CyborgDB ${{ needs.compute_version.outputs.env == 'dev' && 'Dev' || needs.compute_version.outputs.env == 'staging' && 'Staging' || 'Prod' }}/CYBORGDB_API_KEY_STANDARD"
 
-      - name: Load Extra Index URL from 1Password
+      - name: Load CodeArtifact account ID from 1Password
         if: needs.compute_version.outputs.env != 'prod'
         uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TOKEN }}
-          PIP_EXTRA_INDEX_URL: "op://CyborgDB/CyborgDB ${{ needs.compute_version.outputs.env == 'dev' && 'Dev' || 'Staging' }}/PIP_EXTRA_INDEX_URL"
+          CA_AWS_ACCOUNT_ID: "op://CyborgDB/CyborgDB ${{ needs.compute_version.outputs.env == 'dev' && 'Dev' || 'Staging' }}/CA_AWS_ACCOUNT_ID"
+
+      - name: Get CodeArtifact pip index URL
+        if: needs.compute_version.outputs.env != 'prod'
+        id: ca-url
+        uses: ./.github/workflows/actions/codeartifact-pip-url
+        with:
+          aws-account-id: ${{ env.CA_AWS_ACCOUNT_ID }}
+          role-to-assume: arn:aws:iam::${{ env.CA_AWS_ACCOUNT_ID }}:role/CyborgGitHubActionsS3Role
+          codeartifact-repository: ${{ needs.compute_version.outputs.env == 'dev' && 'cyborg-dev' || 'cyborg-staging' }}
+
+      - name: Export PIP_INDEX_URL
+        if: needs.compute_version.outputs.env != 'prod'
+        run: echo "PIP_INDEX_URL=${{ steps.ca-url.outputs.pip-index-url }}" >> $GITHUB_ENV
 
       - name: Install cyborgdb-service
         run: |
@@ -113,8 +127,8 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # Install optional test dependencies
           pip install sentence-transformers
-          # Install cyborgdb-service (from Cloudsmith for dev/staging, PyPI for prod)
-          pip install "cyborgdb-service[embeddings]" --pre ${PIP_EXTRA_INDEX_URL:+--extra-index-url "$PIP_EXTRA_INDEX_URL"}
+          # For dev/staging, PIP_INDEX_URL points at CodeArtifact (PyPI upstream). For prod, it is unset and pip falls back to PyPI.
+          pip install "cyborgdb-service[embeddings]" --pre
 
       - name: Install SDK dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,10 @@ jobs:
   test:
     needs: [lint, compute_version]
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      id-token: write
+
     services:
       postgres:
         image: postgres:15-alpine
@@ -98,14 +101,27 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TOKEN }}
           CYBORGDB_API_KEY: "op://CyborgDB/CyborgDB ${{ needs.compute_version.outputs.env == 'dev' && 'Dev' || needs.compute_version.outputs.env == 'staging' && 'Staging' || 'Prod' }}/CYBORGDB_API_KEY_STANDARD"
 
-      - name: Load Extra Index URL from 1Password
+      - name: Load CodeArtifact account ID from 1Password
         if: needs.compute_version.outputs.env != 'prod'
         uses: 1password/load-secrets-action@v2
         with:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TOKEN }}
-          PIP_EXTRA_INDEX_URL: "op://CyborgDB/CyborgDB ${{ needs.compute_version.outputs.env == 'dev' && 'Dev' || 'Staging' }}/PIP_EXTRA_INDEX_URL"
+          CA_AWS_ACCOUNT_ID: "op://CyborgDB/CyborgDB ${{ needs.compute_version.outputs.env == 'dev' && 'Dev' || 'Staging' }}/CA_AWS_ACCOUNT_ID"
+
+      - name: Get CodeArtifact pip index URL
+        if: needs.compute_version.outputs.env != 'prod'
+        id: ca-url
+        uses: ./.github/workflows/actions/codeartifact-pip-url
+        with:
+          aws-account-id: ${{ env.CA_AWS_ACCOUNT_ID }}
+          role-to-assume: arn:aws:iam::${{ env.CA_AWS_ACCOUNT_ID }}:role/CyborgGitHubActionsS3Role
+          codeartifact-repository: ${{ needs.compute_version.outputs.env == 'dev' && 'cyborg-dev' || 'cyborg-staging' }}
+
+      - name: Export PIP_INDEX_URL
+        if: needs.compute_version.outputs.env != 'prod'
+        run: echo "PIP_INDEX_URL=${{ steps.ca-url.outputs.pip-index-url }}" >> $GITHUB_ENV
 
       - name: Install service dependencies
         run: |
@@ -116,8 +132,8 @@ jobs:
 
       - name: Install cyborgdb-service
         run: |
-          # Install cyborgdb-service (from Cloudsmith for dev/staging, PyPI for prod)
-          pip install "cyborgdb-service[embeddings]" --pre ${PIP_EXTRA_INDEX_URL:+--extra-index-url "$PIP_EXTRA_INDEX_URL"}
+          # For dev/staging, PIP_INDEX_URL points at CodeArtifact (PyPI upstream). For prod, it is unset and pip falls back to PyPI.
+          pip install "cyborgdb-service[embeddings]" --pre
           
       - name: Install SDK dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ await index.upsert({ items });
 const queryVector = [0.1, 0.2, 0.3, /* ... 128 dimensions */];
 const results = await index.query({
   queryVectors: queryVector,
-  topK: 10
+  topK: 10,
+  include: ['distance']
 });
 
 // Print the results

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     testEnvironment: 'node',
     testMatch: [
         "**/*.test.ts",
-        "**/src/__tests__/**/*.ts"
+        "**/src/__tests__/**/*.test.ts"
       ],
     verbose: true,
     testTimeout: 600000, // Default timeout of 60 seconds for all tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1578,21 +1578,22 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.19.tgz",
-      "integrity": "sha512-hmNAcgeLLqNLnu8UK+HVTfB8170eCmAfsy4gFLBYeE+kdsnyO0Hd/Kd42pZi8Cgfux4OMX3yxl+g+/a1ktGe0A==",
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
+      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": ">=0.4.0 <1.0.0",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "uuid": "^10.0.0",
+        "uuid": "^11.1.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
@@ -1623,6 +1624,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1689,6 +1704,13 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -4823,14 +4845,13 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
-      "integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.24.tgz",
+      "integrity": "sha512-P5f3QK8DWbbxj3HtGpZNHRH/HXE7q8eqjUa4LdpSUcr9zfN816V1GXmEjNxf0DTHrSymfgXBgdoku4mJxwsohA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -6097,20 +6118,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2184,9 +2184,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2444,9 +2444,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2840,9 +2840,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3462,9 +3462,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3534,9 +3534,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -4823,9 +4823,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
-      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.21.tgz",
+      "integrity": "sha512-l140hzgqo91T/QKDXLEfRnnxahuwVEVohr9zqpy3BaGDeBdrPiJuNJ2TBhPZxNXNCl68IkVcn555FD3jp5peyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/api_contract.test.ts
+++ b/src/__tests__/api_contract.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import { Client } from '../index';
+import { flattenResults } from './test-helpers';
 import * as dotenv from 'dotenv';
 
 dotenv.config({ path: '.env.local' });
@@ -699,10 +700,7 @@ describe('CyborgDB API Contract Tests', () => {
         topK: 5,
       });
 
-      const results = Array.isArray(response.results) ? response.results : [response.results];
-      const flat = results.length > 0 && Array.isArray(results[0])
-        ? (results as any[]).flat()
-        : results;
+      const flat = flattenResults(response.results);
 
       expect(flat.length).toBeGreaterThan(0);
       flat.forEach((match: any) => {

--- a/src/__tests__/api_contract.test.ts
+++ b/src/__tests__/api_contract.test.ts
@@ -638,7 +638,7 @@ describe('CyborgDB API Contract Tests', () => {
   describe('14 - EncryptedIndex.query()', () => {
     it('should query with single vector (flat array) and return flat results', async () => {
       const queryVector = testVectors[0];
-      const response = await testIndex.query({ queryVectors: queryVector });
+      const response = await testIndex.query({ queryVectors: queryVector, include: ['distance'] });
       
       expect(response).toBeDefined();
       expect(response).toHaveProperty('results');
@@ -697,20 +697,19 @@ describe('CyborgDB API Contract Tests', () => {
       const response = await testIndex.query({
         queryVectors: testVectors[0],
         topK: 5,
-        include: ['metadata']
+        include: ['distance', 'metadata']
       });
-      
+
       const results = Array.isArray(response.results) ? response.results : [response.results];
       if (results.length > 0) {
         const firstResults = Array.isArray(results[0]) ? results[0] : results;
         if (firstResults.length > 0) {
           const firstResult = firstResults[0];
-          // Distance should ALWAYS be present in query results
           const expectedKeys = new Set(['id', 'distance', 'metadata']);
           validateExactKeys(
             firstResult,
             expectedKeys,
-            'query() with include=[metadata]'
+            'query() with include=[distance, metadata]'
           );
         }
       }
@@ -912,7 +911,7 @@ describe('CyborgDB API Contract Tests', () => {
         queryVectors: testVectors[0],
         topK: 10,
         filters: { type: 'binary' },
-        include: ['metadata']
+        include: ['distance', 'metadata']
       });
 
       expect(response).toBeDefined();

--- a/src/__tests__/api_contract.test.ts
+++ b/src/__tests__/api_contract.test.ts
@@ -693,6 +693,27 @@ describe('CyborgDB API Contract Tests', () => {
       });
     });
 
+    it('should not return distance by default (no include param)', async () => {
+      const response = await testIndex.query({
+        queryVectors: testVectors[0],
+        topK: 5,
+      });
+
+      const results = Array.isArray(response.results) ? response.results : [response.results];
+      const flat = results.length > 0 && Array.isArray(results[0])
+        ? (results as any[]).flat()
+        : results;
+
+      expect(flat.length).toBeGreaterThan(0);
+      flat.forEach((match: any) => {
+        validateExactKeys(
+          match,
+          new Set(['id']),
+          'query() result item with default include'
+        );
+      });
+    });
+
     it('should query with specific include parameter', async () => {
       const response = await testIndex.query({
         queryVectors: testVectors[0],

--- a/src/__tests__/concurrency_test.test.ts
+++ b/src/__tests__/concurrency_test.test.ts
@@ -49,9 +49,9 @@
  *     and performance cliffs under high concurrency (20 workers, 4,000 vectors).
  */
 
-import { Client, EncryptedIndex, QueryResultItem } from '../index';
+import { Client, EncryptedIndex } from '../index';
 import type { IndexIVFFlat, IndexIVFPQ, IndexIVFSQ } from '../index';
-import type { Results } from '../models/Results';
+import { flattenResults } from './test-helpers';
 import { randomBytes, randomUUID } from 'crypto';
 import * as dotenv from 'dotenv';
 
@@ -149,15 +149,6 @@ async function waitUntil(
     await sleep(intervalMs);
   }
   throw new Error(`waitUntil timed out after ${timeoutMs}ms`);
-}
-
-/** Extract flat array of QueryResultItem from query response results. */
-function flattenResults(results: Results | QueryResultItem[] | QueryResultItem[][]): QueryResultItem[] {
-  if (!results) return [];
-  if (Array.isArray(results) && results.length > 0 && Array.isArray(results[0])) {
-    return (results as QueryResultItem[][]).flat();
-  }
-  return results as QueryResultItem[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/concurrency_test.test.ts
+++ b/src/__tests__/concurrency_test.test.ts
@@ -294,7 +294,7 @@ describe('ConcurrentReadsAndWrites', () => {
       try {
         for (let q = 0; q < queryCount; q++) {
           const qv = generateRandomVectors(1, DIMENSION)[0];
-          const response = await index.query({ queryVectors: qv, topK: 5 });
+          const response = await index.query({ queryVectors: qv, topK: 5, include: ['distance'] });
           const items = flattenResults(response.results);
           for (const item of items) {
             expect(item.id).toBeTruthy();
@@ -341,7 +341,7 @@ describe('ConcurrentReadsAndWrites', () => {
       try {
         for (let i = 0; i < 15; i++) {
           const qv = generateRandomVectors(1, DIMENSION)[0];
-          const response = await index.query({ queryVectors: qv, topK: 10 });
+          const response = await index.query({ queryVectors: qv, topK: 10, include: ['distance'] });
           const items = flattenResults(response.results);
           for (const item of items) {
             expect(item.id).toBeTruthy();
@@ -910,7 +910,7 @@ describe('StressHighConcurrency', () => {
         // Each worker also queries to validate responses under load
         for (let q = 0; q < 5; q++) {
           const qv = generateRandomVectors(1, DIMENSION)[0];
-          const response = await index.query({ queryVectors: qv, topK: 10 });
+          const response = await index.query({ queryVectors: qv, topK: 10, include: ['distance'] });
           const items = flattenResults(response.results);
           for (const item of items) {
             expect(item.id).toBeTruthy();

--- a/src/__tests__/test-helpers.ts
+++ b/src/__tests__/test-helpers.ts
@@ -1,0 +1,13 @@
+import type { QueryResultItem } from '../index';
+import type { Results } from '../models/Results';
+
+/** Extract flat array of QueryResultItem from query response results. */
+export function flattenResults(
+  results: Results | QueryResultItem[] | QueryResultItem[][]
+): QueryResultItem[] {
+  if (!results) return [];
+  if (Array.isArray(results) && results.length > 0 && Array.isArray(results[0])) {
+    return (results as QueryResultItem[][]).flat();
+  }
+  return results as QueryResultItem[];
+}


### PR DESCRIPTION
## Description (Required)
<!-- Describe your changes in detail, including what was fixed, improved, or added. -->
Fixed query result tests that incorrectly assumed `distance` was returned by default. The contract is that `distance` is only returned when explicitly requested via the `include` parameter — tests that expected `distance` without passing `include: ['distance']` have been corrected, and a new test was added to assert the default-include behavior (only `id` is returned). Also extracted a shared `flattenResults` helper used by both `api_contract.test.ts` and `concurrency_test.test.ts`, tightened `jest.config.js` `testMatch` so non-test files in `src/__tests__/` aren't picked up as suites, and addressed dependency / CI workflow issues.

## Related Issue (Required)
<!-- Link to an issue or explain what problem this PR solves. -->
Fixes the `distance`-by-default test bug on the `distance-bug-fix` branch.

## Scope of This PR (Required)

- [ ] Feature Implementation
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Security Fix
- [x] Bug Fix
- [x] Other (describe below)

**If "Other" was selected, describe the scope here:**
CI/workflow updates (`.github/workflows/test.yml`, `.github/workflows/build_and_publish.yml`, new `codeartifact-pip-url` composite action) and a Jest configuration tightening so that helper files inside `src/__tests__/` are no longer treated as test suites.

## Test Changes (Required)

- **Added/Removed Tests:**
  <!-- List test names here if applicable. If no test changes, select the option below. -->
  - Added: `should not return distance by default (no include param)` in `api_contract.test.ts`
  - Updated: `should query with single vector (flat array) and return flat results` — now passes `include: ['distance']` since distance is opt-in
  - Updated: `should query with specific include parameter` — now requests `['distance', 'metadata']` and asserts both keys are returned
  - Updated: binary-filter query test — now passes `include: ['distance', 'metadata']`

  - [ ] No test changes

- **Reason:**
  <!-- Explain why these tests were changed. If no test changes, select the option below. -->
  The previous tests assumed `distance` was always returned, but the API contract is that `distance` is only present when explicitly listed in `include`. Tests were corrected to match the contract, and a regression test was added to lock in the default behavior. The shared `flattenResults` helper was extracted to remove duplicated inline result-flattening logic across test files.

  - [ ] No test changes

## Breaking Changes

- [ ] This PR introduces breaking changes

  **If checked, please describe:**

  - **Impact:**
    <!-- What will be affected? -->
    N/A

  - **Migration Steps:**
    <!-- How can developers adapt? -->
    N/A

## Performance & Security Considerations

- [x] No known performance impact
- [x] No security concerns
- [ ] Requires additional security review

## Checklist

- [x] Code follows project style guidelines
- [x] Tests have been updated if needed
- [ ] Documentation has been updated if applicable

## Additional Context
<!-- Any other relevant information or concerns. -->
The new `should not return distance by default` test currently fails against the backend because the SDK/server is returning `distance` and `metadata` even when `include` is omitted. That failure is the underlying bug this branch is intended to surface; the fix itself is tracked separately.

---
_Information regarding test changes will be automatically stored in the test log._
