### PR TITLE
test: skip invalid-API-key test when auth is disabled

### DIFF
--- a/src/__tests__/comprehensive_test.test.ts
+++ b/src/__tests__/comprehensive_test.test.ts
@@ -190,22 +190,25 @@ describe("DiskIVF Index Tests", () => {
 describe("Error Handling Tests", () => {
 	const client = createClient();
 
-	(process.env.CYBORGDB_SERVICE_ROOT_KEY ? test : test.skip)("should handle invalid API key", async () => {
-		const invalidClient = new Client({
-			baseUrl: API_URL,
-			apiKey: "invalid-key-12345",
-			verifySsl: false,
-		});
+	(process.env.CYBORGDB_SERVICE_ROOT_KEY ? test : test.skip)(
+		"should handle invalid API key",
+		async () => {
+			const invalidClient = new Client({
+				baseUrl: API_URL,
+				apiKey: "invalid-key-12345",
+				verifySsl: false,
+			});
 
-		await expect(
-			invalidClient.createIndex({
-				indexName: generateUniqueName(),
-				indexKey: generateRandomKey(),
-				dimension: 128,
-				metric: "euclidean",
-			}),
-		).rejects.toThrow();
-	});
+			await expect(
+				invalidClient.createIndex({
+					indexName: generateUniqueName(),
+					indexKey: generateRandomKey(),
+					dimension: 128,
+					metric: "euclidean",
+				}),
+			).rejects.toThrow();
+		},
+	);
 
 	test("should handle malformed requests", async () => {
 		const indexName = generateUniqueName();

--- a/src/__tests__/comprehensive_test.test.ts
+++ b/src/__tests__/comprehensive_test.test.ts
@@ -190,7 +190,7 @@ describe("DiskIVF Index Tests", () => {
 describe("Error Handling Tests", () => {
 	const client = createClient();
 
-	test("should handle invalid API key", async () => {
+	(process.env.CYBORGDB_SERVICE_ROOT_KEY ? test : test.skip)("should handle invalid API key", async () => {
 		const invalidClient = new Client({
 			baseUrl: API_URL,
 			apiKey: "invalid-key-12345",


### PR DESCRIPTION
## Problem
The service e2e's non-RBAC pass runs with no `CYBORGDB_SERVICE_ROOT_KEY`, so authentication is disabled and the server accepts any key. The "should handle invalid API key" test asserts a bad key is rejected, so it fails in that pass (it passes in the RBAC pass where auth is enforced).

## Fix
Gate the test on `CYBORGDB_SERVICE_ROOT_KEY` via `test.skip` so it only runs when auth is enabled. Mirrors the same guard already applied to the Python (`test_invalid_api_key`) and Go (`TestInvalidAPIKeyRejected`) SDK tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)