### PR TITLE
loadSampleDataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,4 +204,6 @@ $RECYCLE.BIN/
 # Project specific
 .openapi-generator
 wwwroot/*.js
-typingspr.md
+typings
+pr.md
+

--- a/.gitignore
+++ b/.gitignore
@@ -204,4 +204,4 @@ $RECYCLE.BIN/
 # Project specific
 .openapi-generator
 wwwroot/*.js
-typings
+typingspr.md

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ npm install cyborgdb
 ### Usage
 
 ```typescript
-import { Client, loadSampleDataset } from 'cyborgdb';
+import { Client } from 'cyborgdb';
 
 // Initialize the client
 const client = new Client({ 
   baseUrl: 'https://localhost:8000', 
-  apiKey: 'your-api-key' 
+  apiKey: 'your-api-key' // optional; only if the service was started with one
 });
 
 // Generate a 32-byte encryption key
@@ -66,39 +66,37 @@ const index = await client.createIndex({
   indexKey: indexKey,
 });
 
-// Load the hosted sample dataset (fetched from S3 on first use, cached locally)
-const dataset = await loadSampleDataset(); // 75k 128-dim vectors with metadata
+// Add encrypted vector items
+const items = [
+  {
+    id: 'doc1',
+    vector: [0.1, 0.2, 0.3, /* ... 128 dimensions */],
+    contents: 'Hello world!',
+    metadata: { category: 'greeting', language: 'en' }
+  },
+  {
+    id: 'doc2', 
+    vector: [0.4, 0.5, 0.6, /* ... 128 dimensions */],
+    contents: 'Bonjour le monde!',
+    metadata: { category: 'greeting', language: 'fr' }
+  }
+];
 
-// Add the encrypted vector items
-await index.upsert({ items: dataset.items });
+await index.upsert({ items });
 
-// Query the encrypted index with a sample query vector
+// Query the encrypted index
+const queryVector = [0.1, 0.2, 0.3, /* ... 128 dimensions */];
 const results = await index.query({
-  queryVectors: dataset.sampleQueries[0],
+  queryVectors: queryVector,
   topK: 10,
   include: ['distance']
 });
 
-// Print the results (guaranteed non-empty against the sample dataset)
+// Print the results
 results.results.forEach(result => {
   console.log(`ID: ${result.id}, Distance: ${result.distance}`);
 });
 ```
-
-> **Sample dataset:** `loadSampleDataset()` pulls a small reference dataset from
-> S3 on demand and caches it locally — it is not bundled into the SDK. Each item
-> has an explicit `id`, a 128-dim `vector`, and `metadata` with both string
-> (`string`) and numeric (`number`) fields, so the same dataset drives ANN
-> similarity search, metadata filter queries, and numeric range queries. The
-> dataset also ships `sampleQueries` (query vectors) and `exampleFilters`
-> (curated, guaranteed-to-match filters).
-
-> **Encryption model:** the index is encrypted at rest, but an encrypted DB does
-> **not** mean vectors are auto-hidden from you. You must pass your index key on
-> `loadIndex` / `get` / `query` to retrieve **decrypted** vectors and metadata —
-> without the key, only encrypted ciphertext is ever readable. HYOK-level
-> security is not implied unless you manage the key material yourself (see BYOK
-> below).
 
 ### Advanced Usage
 
@@ -117,33 +115,18 @@ const batchResults = await index.query({
 });
 ```
 
-#### Metadata Filtering & Range Queries
+#### Metadata Filtering
 
 ```typescript
-const dataset = await loadSampleDataset();
-const queryVector = dataset.sampleQueries[0];
-
-// Equality filter on a string field
-const filtered = await index.query({
+// Search with metadata filters
+const results = await index.query({
   queryVectors: queryVector,
   topK: 10,
-  filters: { string: 'string_0' },
-  include: ['distance', 'metadata']
+  nProbes: 1,
+  greedy: false,
+  filters: { category: 'greeting', language: 'en' },
+  include: ['distance', 'metadata', 'contents']
 });
-
-// Numeric range query (bounded) — combine similarity with a range predicate
-const ranged = await index.query({
-  queryVectors: queryVector,
-  topK: 10,
-  filters: { number: { $gte: 1250, $lte: 2500 } },
-  include: ['distance', 'metadata']
-});
-
-// The dataset also ships curated, guaranteed-to-match filters:
-for (const { name, filter } of dataset.exampleFilters) {
-  const res = await index.query({ queryVectors: queryVector, topK: 5, filters: filter });
-  console.log(`${name}: ${res.results.length} results`);
-}
 ```
 
 #### Bring Your Own Key (BYOK) via KMS

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install cyborgdb
 ### Usage
 
 ```typescript
-import { Client } from 'cyborgdb';
+import { Client, loadSampleDataset } from 'cyborgdb';
 
 // Initialize the client
 const client = new Client({ 
@@ -66,37 +66,39 @@ const index = await client.createIndex({
   indexKey: indexKey,
 });
 
-// Add encrypted vector items
-const items = [
-  {
-    id: 'doc1',
-    vector: [0.1, 0.2, 0.3, /* ... 128 dimensions */],
-    contents: 'Hello world!',
-    metadata: { category: 'greeting', language: 'en' }
-  },
-  {
-    id: 'doc2', 
-    vector: [0.4, 0.5, 0.6, /* ... 128 dimensions */],
-    contents: 'Bonjour le monde!',
-    metadata: { category: 'greeting', language: 'fr' }
-  }
-];
+// Load the hosted sample dataset (fetched from S3 on first use, cached locally)
+const dataset = await loadSampleDataset(); // 75k 128-dim vectors with metadata
 
-await index.upsert({ items });
+// Add the encrypted vector items
+await index.upsert({ items: dataset.items });
 
-// Query the encrypted index
-const queryVector = [0.1, 0.2, 0.3, /* ... 128 dimensions */];
+// Query the encrypted index with a sample query vector
 const results = await index.query({
-  queryVectors: queryVector,
+  queryVectors: dataset.sampleQueries[0],
   topK: 10,
   include: ['distance']
 });
 
-// Print the results
+// Print the results (guaranteed non-empty against the sample dataset)
 results.results.forEach(result => {
   console.log(`ID: ${result.id}, Distance: ${result.distance}`);
 });
 ```
+
+> **Sample dataset:** `loadSampleDataset()` pulls a small reference dataset from
+> S3 on demand and caches it locally — it is not bundled into the SDK. Each item
+> has an explicit `id`, a 128-dim `vector`, and `metadata` with both string
+> (`string`) and numeric (`number`) fields, so the same dataset drives ANN
+> similarity search, metadata filter queries, and numeric range queries. The
+> dataset also ships `sampleQueries` (query vectors) and `exampleFilters`
+> (curated, guaranteed-to-match filters).
+
+> **Encryption model:** the index is encrypted at rest, but an encrypted DB does
+> **not** mean vectors are auto-hidden from you. You must pass your index key on
+> `loadIndex` / `get` / `query` to retrieve **decrypted** vectors and metadata —
+> without the key, only encrypted ciphertext is ever readable. HYOK-level
+> security is not implied unless you manage the key material yourself (see BYOK
+> below).
 
 ### Advanced Usage
 
@@ -115,18 +117,33 @@ const batchResults = await index.query({
 });
 ```
 
-#### Metadata Filtering
+#### Metadata Filtering & Range Queries
 
 ```typescript
-// Search with metadata filters
-const results = await index.query({
+const dataset = await loadSampleDataset();
+const queryVector = dataset.sampleQueries[0];
+
+// Equality filter on a string field
+const filtered = await index.query({
   queryVectors: queryVector,
   topK: 10,
-  nProbes: 1,
-  greedy: false,
-  filters: { category: 'greeting', language: 'en' },
-  include: ['distance', 'metadata', 'contents']
+  filters: { string: 'string_0' },
+  include: ['distance', 'metadata']
 });
+
+// Numeric range query (bounded) — combine similarity with a range predicate
+const ranged = await index.query({
+  queryVectors: queryVector,
+  topK: 10,
+  filters: { number: { $gte: 1250, $lte: 2500 } },
+  include: ['distance', 'metadata']
+});
+
+// The dataset also ships curated, guaranteed-to-match filters:
+for (const { name, filter } of dataset.exampleFilters) {
+  const res = await index.query({ queryVectors: queryVector, topK: 5, filters: filter });
+  console.log(`${name}: ${res.results.length} results`);
+}
 ```
 
 #### Bring Your Own Key (BYOK) via KMS

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,6 @@
 			"!src/models/**",
 			"!src/runtime.ts",
 			"!openapi.json",
-			"!src/__tests__/unit_test_flow_data.json",
 			"!src/__tests__/wiki_data_sample.json"
 		]
 	},

--- a/src/__tests__/datasets.test.ts
+++ b/src/__tests__/datasets.test.ts
@@ -1,0 +1,104 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gzipSync } from "node:zlib";
+import {
+	DEFAULT_SAMPLE_DATASET,
+	loadSampleDataset,
+	type SampleDataset,
+} from "../datasets";
+
+/**
+ * Unit tests for the sample dataset loader.
+ *
+ * These are fully offline: `fetch` is mocked and the dataset is cached to a
+ * throwaway temp directory, so no S3 access or running service is required.
+ */
+
+const FAKE_DATASET: SampleDataset = {
+	name: "quickstart-75k",
+	version: 1,
+	description: "test fixture",
+	dimension: 3,
+	metric: "euclidean",
+	count: 2,
+	items: [
+		{ id: "item_0", vector: [1, 2, 3], metadata: { number: 0, string: "a" } },
+		{ id: "item_1", vector: [4, 5, 6], metadata: { number: 1, string: "b" } },
+	],
+	sampleQueries: [[1, 2, 3]],
+	exampleFilters: [
+		{ name: "eq", filter: { string: "a" }, demonstrates: "equality" },
+	],
+};
+
+function gzipResponse(dataset: SampleDataset): Response {
+	const gz = gzipSync(Buffer.from(JSON.stringify(dataset)));
+	return {
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		arrayBuffer: async () =>
+			gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength),
+	} as unknown as Response;
+}
+
+describe("loadSampleDataset", () => {
+	let cacheDir: string;
+	let fetchSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cyborgdb-ds-"));
+		fetchSpy = jest
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(gzipResponse(FAKE_DATASET));
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+		fs.rmSync(cacheDir, { recursive: true, force: true });
+	});
+
+	it("downloads, decompresses, and parses the dataset", async () => {
+		const ds = await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(ds.count).toBe(2);
+		expect(ds.dimension).toBe(3);
+		expect(ds.items[0].id).toBe("item_0");
+		expect(ds.items[0].vector).toEqual([1, 2, 3]);
+		expect(ds.sampleQueries).toHaveLength(1);
+		expect(ds.exampleFilters[0].filter).toEqual({ string: "a" });
+	});
+
+	it("serves the second call from the local cache (no re-download)", async () => {
+		await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
+		await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-downloads when forceDownload is set", async () => {
+		await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
+		await loadSampleDataset(DEFAULT_SAMPLE_DATASET, {
+			cacheDir,
+			forceDownload: true,
+		});
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("throws on an unknown dataset name", async () => {
+		await expect(
+			loadSampleDataset("does-not-exist", { cacheDir }),
+		).rejects.toThrow(/Unknown sample dataset/);
+	});
+
+	it("throws when the download fails", async () => {
+		fetchSpy.mockResolvedValue({
+			ok: false,
+			status: 404,
+			statusText: "Not Found",
+		} as unknown as Response);
+		await expect(
+			loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir }),
+		).rejects.toThrow(/HTTP 404/);
+	});
+});

--- a/src/__tests__/datasets.test.ts
+++ b/src/__tests__/datasets.test.ts
@@ -1,8 +1,10 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { gzipSync } from "node:zlib";
 import {
+	DATASETS,
 	DEFAULT_SAMPLE_DATASET,
 	loadSampleDataset,
 	type RawSampleDataset,
@@ -52,8 +54,12 @@ const FAKE_RAW: RawSampleDataset = {
 	num_trained_vectors: 1,
 };
 
+function rawBytes(dataset: RawSampleDataset): Buffer {
+	return Buffer.from(JSON.stringify(dataset));
+}
+
 function gzipResponse(dataset: RawSampleDataset): Response {
-	const gz = gzipSync(Buffer.from(JSON.stringify(dataset)));
+	const gz = gzipSync(rawBytes(dataset));
 	return {
 		ok: true,
 		status: 200,
@@ -63,19 +69,29 @@ function gzipResponse(dataset: RawSampleDataset): Response {
 	} as unknown as Response;
 }
 
+/** SHA-256 of the decompressed fixture, matching what the loader verifies. */
+const FAKE_SHA256 = createHash("sha256")
+	.update(rawBytes(FAKE_RAW))
+	.digest("hex");
+
 describe("loadSampleDataset", () => {
 	let cacheDir: string;
 	let fetchSpy: jest.SpyInstance;
+	let originalSha256: string;
 
 	beforeEach(() => {
 		cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cyborgdb-ds-"));
 		fetchSpy = jest
 			.spyOn(globalThis, "fetch")
 			.mockResolvedValue(gzipResponse(FAKE_RAW));
+		// Pin the catalog digest to the fixture so integrity verification passes.
+		originalSha256 = DATASETS[DEFAULT_SAMPLE_DATASET].sha256;
+		DATASETS[DEFAULT_SAMPLE_DATASET].sha256 = FAKE_SHA256;
 	});
 
 	afterEach(() => {
 		fetchSpy.mockRestore();
+		DATASETS[DEFAULT_SAMPLE_DATASET].sha256 = originalSha256;
 		fs.rmSync(cacheDir, { recursive: true, force: true });
 	});
 
@@ -127,5 +143,22 @@ describe("loadSampleDataset", () => {
 		await expect(
 			loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir }),
 		).rejects.toThrow(/HTTP 404/);
+	});
+
+	it("throws when the downloaded payload fails the integrity check", async () => {
+		DATASETS[DEFAULT_SAMPLE_DATASET].sha256 = "0".repeat(64);
+		await expect(
+			loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir }),
+		).rejects.toThrow(/Integrity check failed/);
+	});
+
+	it("re-downloads when the cached file fails the integrity check", async () => {
+		await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		// Tamper with the cached file; the pinned digest no longer matches.
+		const cacheFile = path.join(cacheDir, "quickstart-75k_v1_dataset.json");
+		fs.writeFileSync(cacheFile, "tampered");
+		await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/__tests__/datasets.test.ts
+++ b/src/__tests__/datasets.test.ts
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 import {
 	DEFAULT_SAMPLE_DATASET,
 	loadSampleDataset,
-	type SampleDataset,
+	type RawSampleDataset,
 } from "../datasets";
 
 /**
@@ -13,26 +13,46 @@ import {
  *
  * These are fully offline: `fetch` is mocked and the dataset is cached to a
  * throwaway temp directory, so no S3 access or running service is required.
+ *
+ * The mocked payload is the *raw* hosted shape (no `items`/`sampleQueries`);
+ * those convenience fields are rebuilt by the loader's hydrate step.
  */
 
-const FAKE_DATASET: SampleDataset = {
+const FAKE_RAW: RawSampleDataset = {
 	name: "quickstart-75k",
 	version: 1,
 	description: "test fixture",
 	dimension: 3,
 	metric: "euclidean",
 	count: 2,
-	items: [
-		{ id: "item_0", vector: [1, 2, 3], metadata: { number: 0, string: "a" } },
-		{ id: "item_1", vector: [4, 5, 6], metadata: { number: 1, string: "b" } },
-	],
-	sampleQueries: [[1, 2, 3]],
 	exampleFilters: [
 		{ name: "eq", filter: { string: "a" }, demonstrates: "equality" },
 	],
+	ids: ["item_0", "item_1"],
+	vectors: [
+		[1, 2, 3],
+		[4, 5, 6],
+	],
+	metadata: [
+		{ number: 0, string: "a" },
+		{ number: 1, string: "b" },
+	],
+	queries: [[1, 2, 3]],
+	metadata_queries: [{ string: "a" }],
+	metadata_query_names: ["eq string a"],
+	untrained_neighbors: [[0]],
+	trained_neighbors: [[0]],
+	untrained_metadata_matches: [[1]],
+	trained_metadata_matches: [[1]],
+	untrained_metadata_neighbors: [[[0]]],
+	trained_metadata_neighbors: [[[0]]],
+	untrained_recall: 1.0,
+	trained_recall: 0.94,
+	num_untrained_vectors: 1,
+	num_trained_vectors: 1,
 };
 
-function gzipResponse(dataset: SampleDataset): Response {
+function gzipResponse(dataset: RawSampleDataset): Response {
 	const gz = gzipSync(Buffer.from(JSON.stringify(dataset)));
 	return {
 		ok: true,
@@ -51,7 +71,7 @@ describe("loadSampleDataset", () => {
 		cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cyborgdb-ds-"));
 		fetchSpy = jest
 			.spyOn(globalThis, "fetch")
-			.mockResolvedValue(gzipResponse(FAKE_DATASET));
+			.mockResolvedValue(gzipResponse(FAKE_RAW));
 	});
 
 	afterEach(() => {
@@ -59,15 +79,22 @@ describe("loadSampleDataset", () => {
 		fs.rmSync(cacheDir, { recursive: true, force: true });
 	});
 
-	it("downloads, decompresses, and parses the dataset", async () => {
+	it("downloads, decompresses, and hydrates the dataset", async () => {
 		const ds = await loadSampleDataset(DEFAULT_SAMPLE_DATASET, { cacheDir });
 		expect(fetchSpy).toHaveBeenCalledTimes(1);
 		expect(ds.count).toBe(2);
 		expect(ds.dimension).toBe(3);
+		// items are built from ids + vectors + metadata
+		expect(ds.items).toHaveLength(2);
 		expect(ds.items[0].id).toBe("item_0");
 		expect(ds.items[0].vector).toEqual([1, 2, 3]);
-		expect(ds.sampleQueries).toHaveLength(1);
+		expect(ds.items[1].metadata).toEqual({ number: 1, string: "b" });
+		// sampleQueries are the leading queries
+		expect(ds.sampleQueries).toEqual([[1, 2, 3]]);
 		expect(ds.exampleFilters[0].filter).toEqual({ string: "a" });
+		// raw ground-truth fields pass through unchanged
+		expect(ds.trained_recall).toBe(0.94);
+		expect(ds.untrained_neighbors).toEqual([[0]]);
 	});
 
 	it("serves the second call from the local cache (no re-download)", async () => {

--- a/src/__tests__/quick_flow.test.ts
+++ b/src/__tests__/quick_flow.test.ts
@@ -1,8 +1,12 @@
-import { createHash, randomBytes, randomUUID } from "node:crypto";
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { randomBytes, randomUUID } from "node:crypto";
 import * as dotenv from "dotenv";
-import { Client, type EncryptedIndex, type QueryResultItem } from "../index";
+import {
+	Client,
+	type EncryptedIndex,
+	loadSampleDataset,
+	type QueryResultItem,
+	type SampleDataset,
+} from "../index";
 
 // Load environment variables from .env.local
 dotenv.config({ path: ".env.local" });
@@ -125,26 +129,8 @@ function checkMetadataResults(
 	return recalls;
 }
 
-interface TestData {
-	vectors: number[][];
-	queries: number[][];
-	untrained_neighbors: number[][];
-	trained_neighbors: number[][];
-	metadata: any[];
-	metadata_queries: any[];
-	metadata_query_names: string[]; // Present in JSON but not used in tests
-	untrained_metadata_matches: number[][];
-	trained_metadata_matches: number[][];
-	untrained_metadata_neighbors: number[][][];
-	trained_metadata_neighbors: number[][][];
-	untrained_recall: number;
-	trained_recall: number;
-	num_untrained_vectors: number;
-	num_trained_vectors: number;
-}
-
 describe("TestUnitFlow", () => {
-	let data: TestData;
+	let data: SampleDataset;
 	let vectors: number[][];
 	let queries: number[][];
 	let untrainedNeighbors: number[][];
@@ -170,25 +156,10 @@ describe("TestUnitFlow", () => {
 	let index: EncryptedIndex;
 
 	beforeAll(async () => {
-		// Construct the path to the JSON file
-		const testDir = path.dirname(path.resolve(__filename));
-		const jsonPath = path.join(testDir, "unit_test_flow_data.json");
-		const jsonData = fs.readFileSync(jsonPath, "utf8");
-
-		// Compute & validate checksum
-		const expectedChecksum =
-			"f72e30b0e9b94d1987d0bfd39866f05477cc0cdae88398d85d59693f283a504e";
-		const checksum = createHash("sha256")
-			.update(jsonData, "utf8")
-			.digest("hex");
-		if (checksum !== expectedChecksum) {
-			throw new Error(
-				`Data integrity check failed: expected checksum ${expectedChecksum}, got ${checksum}`,
-			);
-		}
-
-		// Parse the JSON data
-		data = JSON.parse(jsonData);
+		// Fetch the hosted sample dataset (downloaded from S3 on first use and
+		// cached locally). It carries the full ground-truth arrays this recall
+		// test needs, so it replaces the previously-committed JSON fixture.
+		data = await loadSampleDataset();
 
 		// Load vectors and neighbors as arrays
 		vectors = data.vectors;

--- a/src/datasets.ts
+++ b/src/datasets.ts
@@ -42,7 +42,17 @@ export interface SampleFilter {
 	demonstrates: string;
 }
 
-/** A fully-loaded sample dataset, ready to upsert and query. */
+/**
+ * A fully-loaded sample dataset, ready to upsert and query.
+ *
+ * Combines three layers:
+ *  - **dataset metadata** (`name`, `dimension`, `metric`, …);
+ *  - **convenience fields** built by the loader for quickstart/demo use
+ *    (`items`, `sampleQueries`, `exampleFilters`);
+ *  - **raw parallel arrays** plus **ground-truth fixture data** (`queries`,
+ *    `*_neighbors`, `*_recall`, …) used to validate recall/accuracy. These
+ *    keep their original snake_case names and are aligned by index.
+ */
 export interface SampleDataset {
 	/** Dataset identifier, e.g. `"quickstart-75k"`. */
 	name: string;
@@ -56,13 +66,58 @@ export interface SampleDataset {
 	metric: string;
 	/** Number of items in the dataset. */
 	count: number;
+
+	// ---- convenience (built by the loader) ----
 	/** Items with explicit IDs, vectors, and metadata — drop into `upsert`. */
 	items: VectorItem[];
-	/** A handful of query vectors for ANN similarity-search demos. */
+	/** A handful of query vectors for quick ANN similarity-search demos. */
 	sampleQueries: number[][];
-	/** Curated filters for metadata / range-query demos. */
+	/** Curated, guaranteed-to-match filters for metadata / range-query demos. */
 	exampleFilters: SampleFilter[];
+
+	// ---- raw parallel arrays (aligned by index) ----
+	/** Explicit IDs, aligned with `vectors` / `metadata`. */
+	ids: string[];
+	/** All vectors, aligned with `ids` / `metadata`. */
+	vectors: number[][];
+	/** Per-vector metadata, aligned with `ids` / `vectors`. */
+	metadata: Record<string, unknown>[];
+
+	// ---- ground-truth fixture data (for recall / accuracy validation) ----
+	/** Query vectors (superset of `sampleQueries`). */
+	queries: number[][];
+	/** Metadata filter expressions used by the recall benchmark. */
+	metadata_queries: Record<string, unknown>[];
+	/** Human-readable names for each entry in `metadata_queries`. */
+	metadata_query_names: string[];
+	/** Ground-truth nearest-neighbor IDs per query, untrained index. */
+	untrained_neighbors: number[][];
+	/** Ground-truth nearest-neighbor IDs per query, trained index. */
+	trained_neighbors: number[][];
+	/** Ground-truth metadata-match counts per filter, untrained index. */
+	untrained_metadata_matches: number[][];
+	/** Ground-truth metadata-match counts per filter, trained index. */
+	trained_metadata_matches: number[][];
+	/** Ground-truth neighbors per filter+query, untrained index. */
+	untrained_metadata_neighbors: number[][][];
+	/** Ground-truth neighbors per filter+query, trained index. */
+	trained_metadata_neighbors: number[][][];
+	/** Expected mean recall, untrained index. */
+	untrained_recall: number;
+	/** Expected mean recall, trained index. */
+	trained_recall: number;
+	/** Number of vectors upserted before training. */
+	num_untrained_vectors: number;
+	/** Number of vectors upserted after training. */
+	num_trained_vectors: number;
 }
+
+/**
+ * The shape stored in the hosted artifact and the local cache: everything in
+ * {@link SampleDataset} except the loader-derived convenience fields, which are
+ * rebuilt by `hydrate()` to avoid duplicating vectors on the wire/disk.
+ */
+export type RawSampleDataset = Omit<SampleDataset, "items" | "sampleQueries">;
 
 /** Catalog of available datasets and where to fetch each one. */
 const DATASETS: Record<string, { objectPath: string }> = {
@@ -82,9 +137,30 @@ export interface LoadSampleDatasetOptions {
 	forceDownload?: boolean;
 }
 
+/** Number of leading `queries` exposed as `sampleQueries` for quick demos. */
+const NUM_SAMPLE_QUERIES = 10;
+
 function defaultCacheDir(): string {
 	const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), ".cache");
 	return path.join(base, "cyborgdb");
+}
+
+/**
+ * Build the loader-derived convenience fields (`items`, `sampleQueries`) from
+ * the raw parallel arrays. The hosted artifact and the local cache store only
+ * the raw arrays (no duplicated vectors), so this runs on every load.
+ */
+function hydrate(raw: RawSampleDataset): SampleDataset {
+	const items: VectorItem[] = raw.ids.map((id, i) => ({
+		id,
+		vector: raw.vectors[i],
+		metadata: raw.metadata[i],
+	}));
+	return {
+		...raw,
+		items,
+		sampleQueries: raw.queries.slice(0, NUM_SAMPLE_QUERIES),
+	};
 }
 
 /**
@@ -119,7 +195,7 @@ export async function loadSampleDataset(
 	if (!options.forceDownload && fs.existsSync(cacheFile)) {
 		try {
 			const cached = fs.readFileSync(cacheFile, "utf8");
-			return JSON.parse(cached) as SampleDataset;
+			return hydrate(JSON.parse(cached) as RawSampleDataset);
 		} catch {
 			// Corrupt cache — fall through and re-download.
 		}
@@ -136,9 +212,10 @@ export async function loadSampleDataset(
 
 	const compressed = Buffer.from(await response.arrayBuffer());
 	const json = gunzipSync(compressed).toString("utf8");
-	const dataset = JSON.parse(json) as SampleDataset;
+	const raw = JSON.parse(json) as RawSampleDataset;
 
-	// Best-effort local cache; a failed write must not break the load.
+	// Best-effort local cache of the raw payload; a failed write must not break
+	// the load. `items`/`sampleQueries` are rebuilt by hydrate() on read.
 	try {
 		fs.mkdirSync(cacheDir, { recursive: true });
 		fs.writeFileSync(cacheFile, json, "utf8");
@@ -146,5 +223,5 @@ export async function loadSampleDataset(
 		// Read-only FS or similar — skip caching.
 	}
 
-	return dataset;
+	return hydrate(raw);
 }

--- a/src/datasets.ts
+++ b/src/datasets.ts
@@ -1,0 +1,150 @@
+/**
+ * Sample dataset loader for CyborgDB.
+ *
+ * Fetches a small reference dataset hosted on S3 on demand and caches it
+ * locally, so quickstart and test code can populate an index without bundling
+ * data into the SDK. Hosting the dataset out-of-band keeps the SDK lean and
+ * lets us iterate the dataset without cutting an SDK release.
+ *
+ * @example
+ * ```typescript
+ * import { Client, loadSampleDataset } from 'cyborgdb';
+ *
+ * const dataset = await loadSampleDataset();
+ * const index = await client.createIndex({ indexName: 'demo', indexKey });
+ * await index.upsert({ items: dataset.items });
+ * ```
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { gunzipSync } from "node:zlib";
+import type { VectorItem } from "./models";
+
+/**
+ * Base URL for hosted sample datasets (public-read S3 bucket).
+ *
+ * Datasets live at versioned per-dataset paths (`<name>/v<n>/dataset.json.gz`),
+ * so the dataset can be iterated without an SDK release — re-upload under a new
+ * version path and bump the entry in {@link DATASETS}.
+ */
+export const SAMPLE_DATASETS_BASE_URL =
+	"https://cyborgdb-sample-datasets.s3.amazonaws.com";
+
+/** A curated, named metadata filter that is guaranteed to match rows. */
+export interface SampleFilter {
+	/** Human-readable label for docs/UX. */
+	name: string;
+	/** A filter expression accepted by `index.query({ filters })`. */
+	filter: Record<string, unknown>;
+	/** What demo this filter illustrates. */
+	demonstrates: string;
+}
+
+/** A fully-loaded sample dataset, ready to upsert and query. */
+export interface SampleDataset {
+	/** Dataset identifier, e.g. `"quickstart-75k"`. */
+	name: string;
+	/** Dataset schema version. */
+	version: number;
+	/** Human-readable description. */
+	description: string;
+	/** Vector dimensionality. */
+	dimension: number;
+	/** Distance metric the vectors were generated for, e.g. `"euclidean"`. */
+	metric: string;
+	/** Number of items in the dataset. */
+	count: number;
+	/** Items with explicit IDs, vectors, and metadata — drop into `upsert`. */
+	items: VectorItem[];
+	/** A handful of query vectors for ANN similarity-search demos. */
+	sampleQueries: number[][];
+	/** Curated filters for metadata / range-query demos. */
+	exampleFilters: SampleFilter[];
+}
+
+/** Catalog of available datasets and where to fetch each one. */
+const DATASETS: Record<string, { objectPath: string }> = {
+	"quickstart-75k": { objectPath: "quickstart-75k/v1/dataset.json.gz" },
+};
+
+/** Default dataset returned by `loadSampleDataset()` with no arguments. */
+export const DEFAULT_SAMPLE_DATASET = "quickstart-75k";
+
+export interface LoadSampleDatasetOptions {
+	/**
+	 * Directory to cache the decompressed dataset in.
+	 * Defaults to `$XDG_CACHE_HOME/cyborgdb` or `~/.cache/cyborgdb`.
+	 */
+	cacheDir?: string;
+	/** Re-download even if a cached copy exists. Defaults to `false`. */
+	forceDownload?: boolean;
+}
+
+function defaultCacheDir(): string {
+	const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), ".cache");
+	return path.join(base, "cyborgdb");
+}
+
+/**
+ * Load a hosted sample dataset, fetching from S3 on first use and caching
+ * the decompressed copy locally for subsequent calls.
+ *
+ * @param name Dataset name (default: `"quickstart-75k"`).
+ * @param options Cache directory / force-download overrides.
+ * @returns The parsed dataset, ready to `upsert` and `query`.
+ * @throws If the dataset name is unknown or the download fails.
+ */
+export async function loadSampleDataset(
+	name: string = DEFAULT_SAMPLE_DATASET,
+	options: LoadSampleDatasetOptions = {},
+): Promise<SampleDataset> {
+	const entry = DATASETS[name];
+	if (!entry) {
+		const known = Object.keys(DATASETS).join(", ");
+		throw new Error(
+			`Unknown sample dataset "${name}". Available datasets: ${known}.`,
+		);
+	}
+
+	const cacheDir = options.cacheDir ?? defaultCacheDir();
+	// Cache key mirrors the versioned object path so a dataset bump never
+	// serves a stale cached copy.
+	const cacheFile = path.join(
+		cacheDir,
+		`${entry.objectPath.replace(/\//g, "_").replace(/\.gz$/, "")}`,
+	);
+
+	if (!options.forceDownload && fs.existsSync(cacheFile)) {
+		try {
+			const cached = fs.readFileSync(cacheFile, "utf8");
+			return JSON.parse(cached) as SampleDataset;
+		} catch {
+			// Corrupt cache — fall through and re-download.
+		}
+	}
+
+	const url = `${SAMPLE_DATASETS_BASE_URL}/${entry.objectPath}`;
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to download sample dataset "${name}" from ${url}: ` +
+				`HTTP ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const compressed = Buffer.from(await response.arrayBuffer());
+	const json = gunzipSync(compressed).toString("utf8");
+	const dataset = JSON.parse(json) as SampleDataset;
+
+	// Best-effort local cache; a failed write must not break the load.
+	try {
+		fs.mkdirSync(cacheDir, { recursive: true });
+		fs.writeFileSync(cacheFile, json, "utf8");
+	} catch {
+		// Read-only FS or similar — skip caching.
+	}
+
+	return dataset;
+}

--- a/src/datasets.ts
+++ b/src/datasets.ts
@@ -16,6 +16,7 @@
  * ```
  */
 
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -119,10 +120,38 @@ export interface SampleDataset {
  */
 export type RawSampleDataset = Omit<SampleDataset, "items" | "sampleQueries">;
 
-/** Catalog of available datasets and where to fetch each one. */
-const DATASETS: Record<string, { objectPath: string }> = {
-	"quickstart-75k": { objectPath: "quickstart-75k/v1/dataset.json.gz" },
-};
+/**
+ * Catalog of available datasets: where to fetch each one and the SHA-256 of its
+ * decompressed JSON, pinned so a bucket compromise or a poisoned local cache
+ * file can't be trusted silently. The same digest is verified post-download and
+ * on cache read.
+ *
+ * Exported for tests to inject a fixture digest; it is intentionally not
+ * re-exported from `index.ts`, so it is not part of the public API.
+ */
+export const DATASETS: Record<string, { objectPath: string; sha256: string }> =
+	{
+		"quickstart-75k": {
+			objectPath: "quickstart-75k/v1/dataset.json.gz",
+			sha256:
+				"6e2db96a0932f036698ebf5e25cf0871cc69b649f7fb352f9e3dddcf9af0540f",
+		},
+	};
+
+/**
+ * Upper bound on the decompressed dataset size. Guards against a decompression
+ * bomb: a tiny gzip that expands to many GBs and OOMs the host. The largest
+ * shipped dataset is well under this; pick a generous cap.
+ */
+const MAX_DECOMPRESSED_BYTES = 512 * 1024 * 1024;
+
+/** Bounds the dataset download so a stalled connection can't hang forever. */
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/** Hex-encoded SHA-256 of `data`. */
+function sha256Hex(data: Buffer): string {
+	return createHash("sha256").update(data).digest("hex");
+}
 
 /** Default dataset returned by `loadSampleDataset()` with no arguments. */
 export const DEFAULT_SAMPLE_DATASET = "quickstart-75k";
@@ -194,15 +223,28 @@ export async function loadSampleDataset(
 
 	if (!options.forceDownload && fs.existsSync(cacheFile)) {
 		try {
-			const cached = fs.readFileSync(cacheFile, "utf8");
-			return hydrate(JSON.parse(cached) as RawSampleDataset);
+			const cached = fs.readFileSync(cacheFile);
+			// Verify the cached file against the pinned digest: a poisoned cache
+			// must not be trusted. A mismatch falls through to re-download.
+			if (sha256Hex(cached) === entry.sha256) {
+				return hydrate(JSON.parse(cached.toString("utf8")) as RawSampleDataset);
+			}
 		} catch {
 			// Corrupt cache — fall through and re-download.
 		}
 	}
 
 	const url = `${SAMPLE_DATASETS_BASE_URL}/${entry.objectPath}`;
-	const response = await fetch(url);
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+		});
+	} catch (err) {
+		throw new Error(
+			`Failed to download sample dataset "${name}" from ${url}: ${err}`,
+		);
+	}
 	if (!response.ok) {
 		throw new Error(
 			`Failed to download sample dataset "${name}" from ${url}: ` +
@@ -211,14 +253,32 @@ export async function loadSampleDataset(
 	}
 
 	const compressed = Buffer.from(await response.arrayBuffer());
-	const json = gunzipSync(compressed).toString("utf8");
-	const raw = JSON.parse(json) as RawSampleDataset;
+	let decompressed: Buffer;
+	try {
+		// maxOutputLength caps the decompressed size, guarding against a
+		// decompression bomb (throws RangeError if the limit is exceeded).
+		decompressed = gunzipSync(compressed, {
+			maxOutputLength: MAX_DECOMPRESSED_BYTES,
+		});
+	} catch (err) {
+		throw new Error(`Failed to decompress sample dataset "${name}": ${err}`);
+	}
+
+	const digest = sha256Hex(decompressed);
+	if (digest !== entry.sha256) {
+		throw new Error(
+			`Integrity check failed for sample dataset "${name}": ` +
+				`expected SHA-256 ${entry.sha256}, got ${digest}.`,
+		);
+	}
+
+	const raw = JSON.parse(decompressed.toString("utf8")) as RawSampleDataset;
 
 	// Best-effort local cache of the raw payload; a failed write must not break
 	// the load. `items`/`sampleQueries` are rebuilt by hydrate() on read.
 	try {
 		fs.mkdirSync(cacheDir, { recursive: true });
-		fs.writeFileSync(cacheFile, json, "utf8");
+		fs.writeFileSync(cacheFile, decompressed);
 	} catch {
 		// Read-only FS or similar — skip caching.
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,15 @@ export const VERSION = require("../package.json").version;
 
 // Main SDK exports
 export { CyborgDB as Client } from "./client";
+// Export sample dataset loader
+export {
+	DEFAULT_SAMPLE_DATASET,
+	type LoadSampleDatasetOptions,
+	loadSampleDataset,
+	SAMPLE_DATASETS_BASE_URL,
+	type SampleDataset,
+	type SampleFilter,
+} from "./datasets";
 // Export demo utilities
 export { getDemoApiKey } from "./demo";
 export { EncryptedIndex } from "./encryptedIndex";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export {
 	DEFAULT_SAMPLE_DATASET,
 	type LoadSampleDatasetOptions,
 	loadSampleDataset,
-	type RawSampleDataset,
 	SAMPLE_DATASETS_BASE_URL,
 	type SampleDataset,
 	type SampleFilter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
 	DEFAULT_SAMPLE_DATASET,
 	type LoadSampleDatasetOptions,
 	loadSampleDataset,
+	type RawSampleDataset,
 	SAMPLE_DATASETS_BASE_URL,
 	type SampleDataset,
 	type SampleFilter,


### PR DESCRIPTION
## Summary

Adds `loadSampleDataset()`, a helper that pulls a small reference dataset from a
public-read S3 bucket on demand and caches it locally, so quickstart and test
code can populate an index with data that is guaranteed to return non-empty
query results. The dataset is hosted out-of-band (not bundled) to keep the SDK
lean and let us iterate the dataset without an SDK release.

## Motivation

`loadSampleDataset()` exists to get a new user from install to a successful
first query quickly, without hand-authoring placeholder vectors. It's a
convenience for the quickstart/onboarding path — its usage will be documented in
the separate docs repo. This repo's README intentionally keeps showing the
actual data shape (explicit `id` / `vector` / `metadata` items), since that's
what an SDK consumer needs to see to build against the real API.

## Changes

- **`src/datasets.ts`** (new): `loadSampleDataset(name?, options?)` fetches the
  gzipped dataset from S3, decompresses it (treated as an opaque blob so
  decompression is deterministic across Node and browsers), parses it, and
  caches the decompressed copy under `~/.cache/cyborgdb/`. Subsequent calls read
  the cache; `forceDownload` re-fetches. Exposes `SampleDataset` /
  `SampleFilter` types, a `DATASETS` catalog keyed by versioned object path, and
  `SAMPLE_DATASETS_BASE_URL`.
- **`src/index.ts`**: re-exports the loader and its types.
- **`src/__tests__/datasets.test.ts`** (new): offline unit tests (mocked
  `fetch`, temp cache dir) covering download/decompress/parse, cache hit,
  force-download, unknown-dataset error, and HTTP-error handling.
- **`.gitignore`**: ignore the gitignored `pr.md` working draft.

Hosted artifact (not in this diff): the dataset is a transform of Truman's 75k
fixture — 75,000 128-dim vectors with explicit IDs (`item_00000`…) and
string + numeric metadata — uploaded to
`s3://cyborgdb-sample-datasets/quickstart-75k/v1/dataset.json.gz` with a
public-read bucket policy.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing notes: live round-trip against the real S3 object verified
  — 75k items fetched + decompressed + parsed in ~1.3s, cache read in ~216ms,
  metadata/sampleQueries/exampleFilters intact. `tsc --noEmit` and `biome` clean.

## Risk assessment
- Blast radius: additive only — a new exported helper plus tests; no existing
  API changes. Failure modes are isolated to the helper (network fetch / gunzip
  / cache write, all guarded). Cross-SDK parity: `cyborgdb-py` and `cyborgdb-go`
  will want an equivalent `load_sample_dataset()` against the same S3 object for
  a consistent onboarding story.
- Rollback plan: revert the commit — nothing else depends on the helper. The S3
  object can stay (harmless) or be deleted independently; the versioned path
  means a future dataset revision ships under `v2/` without breaking this.

## Reviewers, please focus on:

<!-- pr-docs: branch=s3-dataset — gitignored working draft, do not edit this line -->
