### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -268,7 +268,10 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
-      
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Verify version matches tag
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
@@ -307,15 +310,5 @@ jobs:
           ls -la *.tgz
           npm pack --dry-run
       
-      - name: Load NPM token from 1Password
-        uses: 1password/load-secrets-action@v4
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TOKEN }}
-          NPM_TOKEN: "op://CyborgDB/CyborgDB Prod/NPM_ACCESS_TOKEN"
-
       - name: Publish to NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}


### PR DESCRIPTION
## What

Switch the npm publish step from a long-lived token (loaded from 1Password) to **OIDC trusted publishing**.

The `publish_to_npm` job already runs with `id-token: write` in the `prod` environment, so npm can mint a short-lived credential per run — no stored secret to expire or rotate — and attaches build **provenance** automatically.

## Why

The last `v0.17.0` publish failed with a `404 Not Found - PUT .../cyborgdb`, which is npm's masked auth failure: the `NPM_ACCESS_TOKEN` in 1Password had expired/been revoked. OIDC removes that failure mode entirely.

## Changes

- Upgrade npm to latest before publishing (OIDC trusted publishing needs npm >= 11.5.1; Node 22 ships with npm 10.x).
- Remove the "Load NPM token from 1Password" step and the `NODE_AUTH_TOKEN` env on `npm publish`.

## Required before merge / re-tag

- [x] Trusted publisher configured on npmjs.com (`cyborginc/cyborgdb-js`, workflow `build_and_publish.yml`, environment `prod`).
- [ ] Re-tag `v0.17.0` (or push a new patch tag) to trigger a publish and confirm OIDC works end-to-end.
- [ ] After the first successful OIDC publish, revoke the old `NPM_ACCESS_TOKEN` in 1Password.

Note: the `OP_TOKEN` / 1Password secret stays — the `test` job still uses it for `CYBORGDB_API_KEY`. Only the npm token usage is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)