### PR TITLE
bringing tests into parity

### DIFF
--- a/src/__tests__/api_contract.test.ts
+++ b/src/__tests__/api_contract.test.ts
@@ -10,6 +10,16 @@
 import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 import * as dotenv from "dotenv";
 import { Client, type EncryptedIndex } from "../index";
+import {
+	CreateIndexRequestToJSON,
+	DeleteRequestToJSON,
+	GetRequestToJSON,
+	IndexOperationRequestToJSON,
+	ListIDsRequestToJSON,
+	QueryRequestToJSON,
+	TrainRequestToJSON,
+	UpsertRequestToJSON,
+} from "../models";
 import { flattenResults } from "./test-helpers";
 
 dotenv.config({ path: ".env.local" });
@@ -949,5 +959,82 @@ describe("CyborgDB API Contract Tests", () => {
 			const indexes = await client.listIndexes();
 			expect(indexes).not.toContain(testIndexName);
 		});
+	});
+});
+
+describe("SDK Construction (offline)", () => {
+	// SDK-side construction/serialization checks that need no live service.
+	// Mirrors py TestSDKConstructionOffline / go TestSDKConstructionOffline.
+	// Client construction makes no network calls, so it is safe to instantiate.
+	const offlineClient = new Client({
+		baseUrl: "http://localhost:8000",
+		apiKey: "offline-test-key",
+		verifySsl: false,
+	});
+
+	// Round-trip a model through JSON to see exactly what reaches the wire —
+	// JSON.stringify drops `undefined` keys, which is the service's "no key"
+	// path (matches go's json.Marshal / py's to_dict checks).
+	const wire = (obj: unknown) => JSON.parse(JSON.stringify(obj));
+
+	it("createIndex requires indexKey or kmsName", async () => {
+		await expect(
+			offlineClient.createIndex({ indexName: "x" }),
+		).rejects.toThrow();
+	});
+
+	it("createIndex rejects a wrong-length key", async () => {
+		await expect(
+			offlineClient.createIndex({
+				indexName: "x",
+				indexKey: new Uint8Array(16),
+			}),
+		).rejects.toThrow();
+	});
+
+	it("loadIndex rejects a wrong-length key", async () => {
+		await expect(
+			offlineClient.loadIndex({ indexName: "x", indexKey: new Uint8Array(16) }),
+		).rejects.toThrow();
+	});
+
+	it("CreateIndexRequest with kmsName omits index_key on the wire", () => {
+		const payload = wire(
+			CreateIndexRequestToJSON({ indexName: "x", kmsName: "vendor-slot" }),
+		);
+		expect(payload.index_name).toBe("x");
+		expect(payload.kms_name).toBe("vendor-slot");
+		expect("index_key" in payload).toBe(false);
+	});
+
+	it("IndexOperationRequest keyless omits index_key on the wire", () => {
+		const payload = wire(IndexOperationRequestToJSON({ indexName: "x" }));
+		expect(payload.index_name).toBe("x");
+		expect("index_key" in payload).toBe(false);
+	});
+
+	it("all data-plane requests serialize without an index_key", () => {
+		const cases: Array<[string, unknown]> = [
+			[
+				"QueryRequest",
+				QueryRequestToJSON({ indexName: "x", queryVectors: [0] } as never),
+			],
+			[
+				"UpsertRequest",
+				UpsertRequestToJSON({ indexName: "x", items: [] } as never),
+			],
+			["GetRequest", GetRequestToJSON({ indexName: "x", ids: ["a"] } as never)],
+			[
+				"DeleteRequest",
+				DeleteRequestToJSON({ indexName: "x", ids: ["a"] } as never),
+			],
+			["TrainRequest", TrainRequestToJSON({ indexName: "x" } as never)],
+			["ListIDsRequest", ListIDsRequestToJSON({ indexName: "x" } as never)],
+		];
+		for (const [, json] of cases) {
+			const payload = wire(json);
+			// index_key must be absent or null on the wire (the KMS "no key" path).
+			expect(payload.index_key == null).toBe(true);
+		}
 	});
 });

--- a/src/__tests__/comprehensive_test.test.ts
+++ b/src/__tests__/comprehensive_test.test.ts
@@ -6,6 +6,7 @@
 import { randomBytes } from "node:crypto";
 import * as dotenv from "dotenv";
 import { Client } from "../index";
+import { flattenResults } from "./test-helpers";
 
 // Load environment variables from .env.local
 dotenv.config({ path: ".env.local" });
@@ -442,36 +443,44 @@ describe("Edge Cases Tests", () => {
 	});
 
 	test("should handle boundary values", async () => {
-		const zeroVector = Array(128).fill(0);
-		await index.upsert({
-			items: [
-				{
-					id: "zero_vector",
-					vector: zeroVector,
-					metadata: { type: "zero" },
-				},
+		// Extreme float values must survive the upsert→get round-trip. Expected
+		// values are quantized to float32 (Math.fround) before comparison because
+		// the server stores vectors as float32 while JS numbers are float64.
+		// Mirrors go TestBoundaryVectorValuesRoundTrip /
+		// py test_boundary_vector_values_round_trip.
+		const cases: Array<[string, number[]]> = [
+			["very small (1e-10)", Array(128).fill(1e-10)],
+			["very large (1e10)", Array(128).fill(1e10)],
+			[
+				"mixed signs",
+				Array(128)
+					.fill(0)
+					.map((_, i) => (i % 2 === 0 ? i / 100.0 : -i / 100.0)),
 			],
-		});
+		];
 
-		const smallVector = Array(128).fill(1e-10);
-		await index.upsert({
-			items: [
-				{
-					id: "small_vector",
-					vector: smallVector,
-					metadata: { type: "small" },
-				},
-			],
-		});
+		for (let i = 0; i < cases.length; i++) {
+			await index.upsert({
+				items: [{ id: `boundary_${i}`, vector: cases[i][1] }],
+			});
+		}
+		await new Promise((resolve) => setTimeout(resolve, 2000));
 
-		await new Promise((resolve) => setTimeout(resolve, 1000));
-
-		const results = await index.query({
-			queryVectors: [zeroVector],
-			topK: 2,
-		});
-
-		expect(results.results).toBeDefined();
+		for (let i = 0; i < cases.length; i++) {
+			const vec = cases[i][1];
+			const results = await index.get({
+				ids: [`boundary_${i}`],
+				include: ["vector"],
+			});
+			expect(results.length).toBe(1);
+			const retrieved = results[0].vector as number[];
+			expect(retrieved.length).toBe(128);
+			for (let j = 0; j < vec.length; j++) {
+				const expected = Math.fround(vec[j]);
+				const tol = Math.max(Math.abs(expected) * 1e-4, 1e-4);
+				expect(Math.abs(retrieved[j] - expected)).toBeLessThanOrEqual(tol);
+			}
+		}
 	});
 
 	test("should handle large metadata objects", async () => {
@@ -574,6 +583,182 @@ describe("Backend Compatibility Tests", () => {
 			expect(results.results).toBeDefined();
 		} finally {
 			await index.deleteIndex();
+		}
+	});
+});
+
+describe("Data Integrity Tests", () => {
+	const client = createClient();
+	let index: any;
+	let indexName: string;
+	let indexKey: Uint8Array;
+
+	beforeEach(async () => {
+		indexName = generateUniqueName("integrity");
+		indexKey = generateRandomKey();
+		index = await client.createIndex({
+			indexName,
+			indexKey,
+			dimension: 128,
+			metric: "euclidean",
+		});
+	});
+
+	afterEach(async () => {
+		if (index) {
+			try {
+				await index.deleteIndex();
+			} catch (error) {
+				console.error(`Error cleaning up index: ${error}`);
+			}
+		}
+	});
+
+	test("upsert overwrite preserves latest data", async () => {
+		// Overwriting an ID returns the latest vector and metadata — no stale
+		// cache, and version-1 metadata must not leak into version 2.
+		const vecV1 = Array(128)
+			.fill(0)
+			.map(() => Math.random());
+		await index.upsert({
+			items: [
+				{
+					id: "overwrite_test",
+					vector: vecV1,
+					metadata: { version: 1, old_field: "should_disappear" },
+				},
+			],
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const vecV2 = Array(128)
+			.fill(0)
+			.map(() => Math.random() + 10.0);
+		await index.upsert({
+			items: [
+				{
+					id: "overwrite_test",
+					vector: vecV2,
+					metadata: { version: 2, new_field: "present" },
+				},
+			],
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const results = await index.get({
+			ids: ["overwrite_test"],
+			include: ["vector", "metadata"],
+		});
+		expect(results.length).toBe(1);
+		const retrieved = results[0];
+		for (let i = 0; i < vecV2.length; i++) {
+			expect(retrieved.vector[i]).toBeCloseTo(vecV2[i], 4);
+		}
+		expect(retrieved.metadata.version).toBe(2);
+		expect(retrieved.metadata.new_field).toBe("present");
+	});
+
+	test("delete actually removes data", async () => {
+		// After delete, vectors are gone from get(), listIds(), and query().
+		const vectors = Array(10)
+			.fill(0)
+			.map(() =>
+				Array(128)
+					.fill(0)
+					.map(() => Math.random()),
+			);
+		const ids = vectors.map((_, i) => `del_test_${i}`);
+		await index.upsert({ ids, vectors });
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const deleteIds = ids.slice(0, 5);
+		await index.delete({ ids: deleteIds });
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		// get() returns nothing for deleted IDs
+		const got = await index.get({ ids: deleteIds, include: ["vector"] });
+		expect(got.length).toBe(0);
+
+		// listIds() shows only the surviving 5
+		const listResult = await index.listIds();
+		for (const d of deleteIds) {
+			expect(listResult.ids).not.toContain(d);
+		}
+		expect(listResult.ids.length).toBe(5);
+
+		// query() must not surface a deleted vector
+		const response = await index.query({
+			queryVectors: [vectors[0]],
+			topK: 10,
+		});
+		const returned = flattenResults(response.results).map((it) => it.id);
+		for (const d of deleteIds) {
+			expect(returned).not.toContain(d);
+		}
+	});
+
+	test("get non-existent IDs", async () => {
+		// get() on a mix of real and missing IDs returns only the real ones.
+		await index.upsert({
+			items: [
+				{
+					id: "exists",
+					vector: Array(128)
+						.fill(0)
+						.map(() => Math.random()),
+				},
+			],
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const results = await index.get({
+			ids: ["exists", "ghost_1", "ghost_2"],
+			include: ["vector"],
+		});
+		expect(results.length).toBe(1);
+		expect(results[0].id).toBe("exists");
+	});
+
+	test("duplicate index name rejected", async () => {
+		// `indexName` already exists (created in beforeEach); recreating it must
+		// fail rather than silently overwrite live data.
+		await expect(
+			client.createIndex({
+				indexName,
+				indexKey: generateRandomKey(),
+				dimension: 128,
+				metric: "euclidean",
+			}),
+		).rejects.toThrow();
+	});
+
+	test("wrong key cannot access data", async () => {
+		const name = generateUniqueName("wrongkey");
+		const wrongIndex = await client.createIndex({
+			indexName: name,
+			indexKey: generateRandomKey(),
+			dimension: 128,
+			metric: "euclidean",
+		});
+		try {
+			await wrongIndex.upsert({
+				items: [
+					{
+						id: "secret_data",
+						vector: Array(128)
+							.fill(0)
+							.map(() => Math.random()),
+					},
+				],
+			});
+			await new Promise((resolve) => setTimeout(resolve, 2000));
+
+			// Loading with a different key must be rejected.
+			await expect(
+				client.loadIndex({ indexName: name, indexKey: generateRandomKey() }),
+			).rejects.toThrow();
+		} finally {
+			await wrongIndex.deleteIndex();
 		}
 	});
 });

--- a/src/__tests__/concurrency_test.test.ts
+++ b/src/__tests__/concurrency_test.test.ts
@@ -230,6 +230,35 @@ describe("ConcurrentUpserts", () => {
 			expect(matched).toBe(true);
 		}
 	});
+
+	test("concurrent write then verify per thread", async () => {
+		// 8 workers share one index. Each upserts unique vectors then reads one
+		// back via get() and verifies an exact vector match — catches request/
+		// response routing corruption on the shared client under concurrency.
+		const numWorkers = 8;
+		const errors: Error[] = [];
+
+		const workers = Array.from({ length: numWorkers }, async (_, w) => {
+			try {
+				const { ids, vectors } = await upsertBatch(index, `verify_${w}`, 10);
+				await sleep(1000);
+				const retrieved = await index.get({
+					ids: [ids[0]],
+					include: ["vector"],
+				});
+				expect(retrieved.length).toBe(1);
+				expect(retrieved[0].id).toBe(ids[0]);
+				expect(
+					vectorsApproxEqual(retrieved[0].vector as number[], vectors[0]),
+				).toBe(true);
+			} catch (e: any) {
+				errors.push(e);
+			}
+		});
+
+		await Promise.all(workers);
+		expect(errors).toEqual([]);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -571,6 +600,17 @@ describe("MultiIndexIsolation", () => {
 		}
 	});
 
+	test("list ids isolation", async () => {
+		// Each index's listIds must contain only its own IDs.
+		for (let i = 0; i < indexes.length; i++) {
+			const { ids } = await indexes[i].index.listIds();
+			expect(ids.length).toBeGreaterThan(0);
+			for (const id of ids) {
+				expect(id.startsWith(`idx${i}_`)).toBe(true);
+			}
+		}
+	});
+
 	test("delete in one index doesnt affect others", async () => {
 		// Deleting from index 0 must not remove anything from indexes 1 or 2.
 		const otherSnapshots: Record<number, Set<string>> = {};
@@ -765,5 +805,96 @@ describe("StressHighConcurrency", () => {
 		const storedSet = new Set(storedIds);
 		const missing = allIds.filter((id) => !storedSet.has(id));
 		expect(missing.length).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Index Switching From One Caller (ported from py test_concurrency.py)
+// ---------------------------------------------------------------------------
+
+describe("IndexSwitchingFromOneThread", () => {
+	let client: Client;
+	const numIndexes = 5;
+	let indexes: Array<{ index: EncryptedIndex; name: string; key: Uint8Array }>;
+
+	beforeAll(async () => {
+		client = makeClient();
+		indexes = [];
+		for (let i = 0; i < numIndexes; i++) {
+			indexes.push(await makeIndex(client, `switch_${i}`));
+		}
+	});
+
+	afterAll(async () => {
+		for (const { index } of indexes) {
+			try {
+				await index.deleteIndex();
+			} catch {
+				/* cleanup */
+			}
+		}
+	});
+
+	test("rapid round robin across indexes", async () => {
+		// One caller rapidly alternates ops across indexes: upsert to index i,
+		// query index i+1, etc. Validates the shared client scopes each request
+		// to the right index when touching different indexes back-to-back.
+		const perIndexIds: Record<number, string[]> = {};
+		const perIndexLastVecs: Record<number, number[][]> = {};
+		for (let i = 0; i < numIndexes; i++) {
+			perIndexIds[i] = [];
+		}
+
+		const rounds = 10;
+		const vecsPerRound = 5;
+		for (let r = 0; r < rounds; r++) {
+			for (let idx = 0; idx < numIndexes; idx++) {
+				const ids = Array.from(
+					{ length: vecsPerRound },
+					(_, j) => `sw${idx}_r${r}_${j}`,
+				);
+				const vectors = generateRandomVectors(vecsPerRound, DIMENSION);
+				await indexes[idx].index.upsert({ ids, vectors });
+				perIndexIds[idx].push(...ids);
+				perIndexLastVecs[idx] = vectors;
+
+				// Immediately query a different index to force context switching.
+				const other = (idx + 1) % numIndexes;
+				const response = await indexes[other].index.query({
+					queryVectors: generateRandomVectors(1, DIMENSION)[0],
+					topK: 5,
+				});
+				for (const item of flattenResults(response.results)) {
+					expect(item.id).toBeTruthy();
+				}
+			}
+		}
+
+		await waitUntil(async () => {
+			for (let i = 0; i < numIndexes; i++) {
+				const { ids } = await indexes[i].index.listIds();
+				if (ids.length < perIndexIds[i].length) return false;
+			}
+			return true;
+		});
+
+		// Each index ends with only its own IDs; last-round vectors stay intact.
+		for (let i = 0; i < numIndexes; i++) {
+			const { ids: stored } = await indexes[i].index.listIds();
+			expect(new Set(stored)).toEqual(new Set(perIndexIds[i]));
+
+			const lastIds = perIndexIds[i].slice(-vecsPerRound);
+			const retrieved = await indexes[i].index.get({
+				ids: [lastIds[0]],
+				include: ["vector"],
+			});
+			expect(retrieved.length).toBe(1);
+			expect(
+				vectorsApproxEqual(
+					retrieved[0].vector as number[],
+					perIndexLastVecs[i][0],
+				),
+			).toBe(true);
+		}
 	});
 });

--- a/src/__tests__/langchain_integration.test.ts
+++ b/src/__tests__/langchain_integration.test.ts
@@ -647,4 +647,84 @@ describe("CyborgDB LangChain Integration", () => {
 			expect(docs[0].pageContent).toBe("Valid string content");
 		});
 	});
+
+	describe("Concurrent Async Operations", () => {
+		// Mirrors py TestAsyncConcurrentOperations: the async LangChain path
+		// under concurrent load through a shared CyborgVectorStore.
+		test("concurrent add and search", async () => {
+			// 10 callers add texts concurrently, then 10 search concurrently.
+			const numTasks = 10;
+			const textsPerTask = 10;
+
+			// Warm up so the index exists before the concurrent burst: the JS
+			// CyborgVectorStore initializes lazily on first use and that init is
+			// not concurrency-safe, so a cold parallel burst would race to create
+			// the index. (Python's store tolerates the concurrent first-op init.)
+			await vectorStore.addTexts(["warmup"], undefined, {
+				ids: ["async_warmup"],
+			});
+
+			const addResults = await Promise.allSettled(
+				Array.from({ length: numTasks }, (_, t) =>
+					vectorStore.addTexts(
+						Array.from(
+							{ length: textsPerTask },
+							(_, j) => `task ${t} document ${j} about topic ${t}`,
+						),
+						undefined,
+						{
+							ids: Array.from(
+								{ length: textsPerTask },
+								(_, j) => `async_${t}_${j}`,
+							),
+						},
+					),
+				),
+			);
+			for (const r of addResults) {
+				expect(r.status).toBe("fulfilled");
+				if (r.status === "fulfilled") {
+					expect(r.value).toHaveLength(textsPerTask);
+				}
+			}
+
+			const searchResults = await Promise.allSettled(
+				Array.from({ length: numTasks }, (_, t) =>
+					vectorStore.similaritySearch(`topic ${t}`, 5),
+				),
+			);
+			for (const r of searchResults) {
+				expect(r.status).toBe("fulfilled");
+				if (r.status === "fulfilled") {
+					expect(r.value.length).toBeGreaterThan(0);
+				}
+			}
+		});
+
+		test("concurrent add and delete", async () => {
+			// 5 callers add while 3 delete previously-seeded IDs — no crashes.
+			const seedIds = Array.from({ length: 30 }, (_, i) => `async_del_${i}`);
+			await vectorStore.addTexts(
+				Array.from({ length: 30 }, (_, i) => `deletable document ${i}`),
+				undefined,
+				{ ids: seedIds },
+			);
+
+			const adders = Array.from({ length: 5 }, (_, t) =>
+				vectorStore.addTexts(
+					Array.from({ length: 10 }, (_, j) => `new doc ${t}_${j}`),
+					undefined,
+					{ ids: Array.from({ length: 10 }, (_, j) => `async_new_${t}_${j}`) },
+				),
+			);
+			const deleters = Array.from({ length: 3 }, (_, t) =>
+				vectorStore.delete({ ids: seedIds.slice(t * 10, (t + 1) * 10) }),
+			);
+
+			const results = await Promise.allSettled([...adders, ...deleters]);
+			for (const r of results) {
+				expect(r.status).toBe("fulfilled");
+			}
+		});
+	});
 });

--- a/src/__tests__/rbac_users.test.ts
+++ b/src/__tests__/rbac_users.test.ts
@@ -43,7 +43,10 @@ const BASE_URL =
 	process.env.CYBORGDB_BASE_URL ||
 	"http://localhost:8000";
 const ROOT_API_KEY = process.env.CYBORGDB_SERVICE_ROOT_KEY;
-const KMS_NAME = process.env.CYBORGDB_KMS_NAME;
+// The e2e nightly's RBAC step exports the slot as CYBORGDB_KMS_NAME_REAL; accept
+// the plain CYBORGDB_KMS_NAME too so this runs unchanged in either setup.
+const KMS_NAME =
+	process.env.CYBORGDB_KMS_NAME || process.env.CYBORGDB_KMS_NAME_REAL;
 
 const DIMENSION = 4;
 
@@ -152,14 +155,101 @@ describeIfRbac("CyborgDB RBAC — user management", () => {
 		// biome-ignore lint/style/noNonNullAssertion: guarded by expect above
 		expect([...listed!.permissions].sort()).toEqual(["read", "write"]);
 
-		// Revoke; the key must stop working on the next request.
+		// Revoke; the key must stop working immediately. Revocation drops the
+		// user's wrapped DEK, so even loading the index (which describes it,
+		// gated by the user-wrap check) is denied — hence load or query may
+		// throw. Matches test_list_then_revoke (py) / TestRBACListThenRevoke (go).
 		await index.deleteUser({ userId: out.userId });
 		const after = await index.listUsers();
 		expect(after.map((u) => u.userId)).not.toContain(out.userId);
 
-		const revoked = await userIndex(out.apiKey);
 		await expect(
-			revoked.query({ queryVectors: [0.1, 0.2, 0.3, 0.4], topK: 1 }),
+			(async () => {
+				const revoked = await userIndex(out.apiKey);
+				await revoked.query({ queryVectors: [0.1, 0.2, 0.3, 0.4], topK: 1 });
+			})(),
 		).rejects.toThrow();
+	});
+
+	it("read-only user is listed with read permission", async () => {
+		const out = await index.createUser({ permissions: ["read"] });
+		try {
+			const users = await index.listUsers();
+			const listed = users.find((u) => u.userId === out.userId);
+			expect(listed).toBeDefined();
+			// biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+			expect(listed!.permissions).toEqual(["read"]);
+		} finally {
+			await index.deleteUser({ userId: out.userId });
+		}
+	});
+
+	it("write-only user can write but not query", async () => {
+		const out = await index.createUser({ permissions: ["write"] });
+		try {
+			const writer = await userIndex(out.apiKey);
+			// write op succeeds
+			await writer.upsert({
+				items: [{ id: "wo", vector: [0.0, 0.0, 1.0, 0.0] }],
+			});
+			// read op is cryptographically denied — no read DEK for this user
+			await expect(
+				writer.query({ queryVectors: [0.0, 0.0, 1.0, 0.0], topK: 1 }),
+			).rejects.toThrow();
+		} finally {
+			await index.deleteUser({ userId: out.userId });
+		}
+	});
+
+	it("invalid permissions rejected", async () => {
+		// The grant must be a non-empty subset of {"read","write"}; the service
+		// rejects an empty set and unknown permission names alike.
+		await expect(index.createUser({ permissions: [] })).rejects.toThrow();
+		await expect(
+			index.createUser({ permissions: ["admin"] }),
+		).rejects.toThrow();
+	});
+
+	it("non-root user cannot manage users", async () => {
+		const out = await index.createUser({ permissions: ["read", "write"] });
+		try {
+			const userIdx = await userIndex(out.apiKey);
+			// Minting, listing, and revoking users are root-only operations;
+			// a user key is rejected on each.
+			await expect(
+				userIdx.createUser({ permissions: ["read"] }),
+			).rejects.toThrow();
+			await expect(userIdx.listUsers()).rejects.toThrow();
+			await expect(
+				userIdx.deleteUser({ userId: out.userId }),
+			).rejects.toThrow();
+		} finally {
+			await index.deleteUser({ userId: out.userId });
+		}
+	});
+
+	it("revoking one user leaves another working", async () => {
+		const first = await index.createUser({ permissions: ["read"] });
+		const second = await index.createUser({ permissions: ["read"] });
+		try {
+			// Revoking one user drops only that user's wrapped keys; the other
+			// user's key keeps resolving the index.
+			await index.deleteUser({ userId: first.userId });
+			const survivor = await userIndex(second.apiKey);
+			const results = await survivor.query({
+				queryVectors: [0.1, 0.2, 0.3, 0.4],
+				topK: 1,
+			});
+			expect(Array.isArray(results.results)).toBe(true);
+			expect((results.results as unknown[]).length).toBeGreaterThanOrEqual(1);
+		} finally {
+			for (const u of [first, second]) {
+				try {
+					await index.deleteUser({ userId: u.userId });
+				} catch {
+					/* already revoked */
+				}
+			}
+		}
 	});
 });

--- a/src/__tests__/rerank.test.ts
+++ b/src/__tests__/rerank.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Query rerank_mult knob (0.17.0 API). Mirrors go rerank_test.go and
+ * py test_rerank.py: rerank_mult is the stage-1 retrieval multiplier for
+ * reranking indexes — optional, with a server-side default when unset. This
+ * verifies the SDK threads the value into the request and the server accepts
+ * it on a standard query.
+ */
+
+import { randomBytes, randomUUID } from "node:crypto";
+import * as dotenv from "dotenv";
+import { Client, type EncryptedIndex } from "../index";
+import { flattenResults } from "./test-helpers";
+
+dotenv.config({ path: ".env.local" });
+jest.setTimeout(60000);
+
+const BASE_URL = process.env.CYBORGDB_BASE_URL || "http://localhost:8000";
+const API_KEY = process.env.CYBORGDB_API_KEY || "";
+const DIM = 8;
+
+describe("Query rerankMult", () => {
+	let client: Client;
+	let index: EncryptedIndex;
+
+	beforeAll(async () => {
+		client = new Client({
+			baseUrl: BASE_URL,
+			apiKey: API_KEY,
+			verifySsl: false,
+		});
+		const name = `rerank_${randomUUID().replace(/-/g, "").slice(0, 8)}`;
+		index = await client.createIndex({
+			indexName: name,
+			indexKey: new Uint8Array(randomBytes(32)),
+			dimension: DIM,
+			metric: "euclidean",
+		});
+		const vectors = Array.from({ length: 20 }, () =>
+			Array.from({ length: DIM }, () => Math.random()),
+		);
+		const ids = vectors.map((_, i) => `rerank_${i}`);
+		await index.upsert({ ids, vectors });
+	});
+
+	afterAll(async () => {
+		try {
+			await index.deleteIndex();
+		} catch {
+			/* cleanup */
+		}
+	});
+
+	test("threads rerankMult into the query and the server accepts it", async () => {
+		const qv = Array.from({ length: DIM }, () => Math.random());
+		const response = await index.query({
+			queryVectors: qv,
+			topK: 5,
+			rerankMult: 4,
+			include: ["distance"],
+		});
+		expect(flattenResults(response.results).length).toBeGreaterThanOrEqual(1);
+	});
+});


### PR DESCRIPTION
## Summary

Brings the JS SDK's test suite into parity with `cyborgdb-py` and `cyborgdb-go`
by porting their equivalent test cases. Adds an offline SDK-construction /
serialization suite, a `rerankMult` query test, data-integrity and
boundary-value round-trip tests, additional concurrency and multi-index
isolation tests, async LangChain concurrency tests, and more RBAC permission
tests. Test-only change — no SDK source or public API is touched.

## Motivation

The three sibling SDKs must stay at parity, including their test coverage. The
contract/behavior tests in py and go had grown several cases that JS lacked
(KMS keyless serialization, rerank multiplier, boundary float round-trips,
data-integrity guarantees, index-switching concurrency, async LangChain load,
RBAC permission edges). This PR mirrors those cases so the same guarantees are
exercised across all three clients.

## Changes
- **`src/__tests__/api_contract.test.ts`**: new offline `SDK Construction`
  suite — no live service. Asserts `createIndex`/`loadIndex` reject missing or
  wrong-length keys, and that `kmsName`/keyless requests serialize with
  `index_key` absent or null on the wire (the KMS "no key" path). Mirrors py/go
  `TestSDKConstructionOffline`.
- **`src/__tests__/rerank.test.ts`** (new): verifies the SDK threads
  `rerankMult` (0.17.0 query knob) into the request and the server accepts it.
  Mirrors go `rerank_test.go` / py `test_rerank.py`.
- **`src/__tests__/comprehensive_test.test.ts`**: boundary-value test rewritten
  as an upsert→get round-trip across extreme floats (1e-10, 1e10, mixed signs)
  with float32-quantized (`Math.fround`) tolerance comparison. Adds a `Data
  Integrity` suite: upsert-overwrite freshness, delete removal across
  get/listIds/query, get on non-existent IDs, duplicate-index-name rejection,
  and wrong-key access rejection.
- **`src/__tests__/concurrency_test.test.ts`**: adds per-thread
  concurrent-write-then-verify, `listIds` multi-index isolation, and a
  single-caller rapid index-switching round-robin test (ported from py
  `test_concurrency.py`).
- **`src/__tests__/langchain_integration.test.ts`**: adds an async concurrent
  add/search and concurrent add/delete suite through a shared
  `CyborgVectorStore` (mirrors py `TestAsyncConcurrentOperations`), with a
  warmup upsert to avoid the JS store's non-concurrency-safe lazy init.
- **`src/__tests__/rbac_users.test.ts`**: adds read-only/write-only permission
  scoping, invalid-permission rejection, non-root user management rejection, and
  per-user revocation independence tests.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing notes:

Most added cases are integration tests requiring a live `cyborgdb-service`; the
new `SDK Construction (offline)` suite runs without one.

## Risk assessment
- Blast radius: test-only — no `src/` source or public API changes, so SDK
  consumers are unaffected. Risk is confined to CI: a ported test that assumes
  py/go behavior the JS client doesn't share could fail and block the pipeline
  (e.g. the noted lazy-init race the LangChain warmup guards against).
- Rollback plan: revert the commit — nothing depends on these tests.

## Reviewers, please focus on:

<!-- pr-docs: branch=e2e — gitignored working draft, do not edit this line -->
