### PR TITLE
fix dependabot issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "cyborgdb",
 			"version": "0.17.0",
 			"license": "MIT",
-			"dependencies": {
-				"build": "^0.1.4"
-			},
 			"devDependencies": {
 				"@biomejs/biome": "2.5.1",
 				"@langchain/core": "^1.1.19",
@@ -718,15 +715,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@colors/colors": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
-			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -738,17 +726,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@dabh/diagnostics": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
-			"integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@so-ric/colorspace": "^1.1.6",
-				"enabled": "2.0.x",
-				"kuler": "^2.0.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1935,16 +1912,6 @@
 				"@sinonjs/commons": "^3.0.1"
 			}
 		},
-		"node_modules/@so-ric/colorspace": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
-			"integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
-			"license": "MIT",
-			"dependencies": {
-				"color": "^5.0.2",
-				"text-hex": "1.0.x"
-			}
-		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2069,12 +2036,6 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/triple-beam": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
-			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
 			"license": "MIT"
 		},
 		"node_modules/@ungap/structured-clone": {
@@ -2503,13 +2464,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
 			"license": "Python-2.0"
-		},
-		"node_modules/async": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-			"license": "MIT"
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -2746,34 +2702,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/build": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/build/-/build-0.1.4.tgz",
-			"integrity": "sha512-KwbDJ/zrsU8KZRRMfoURG14cKIAStUlS8D5jBDvtrZbwO5FEkYqc3oB8HIhRiyD64A48w1lc+sOmQ+mmBw5U/Q==",
-			"dependencies": {
-				"cssmin": "0.3.x",
-				"jsmin": "1.x",
-				"jxLoader": "*",
-				"moo-server": "*",
-				"promised-io": "*",
-				"timespan": "2.x",
-				"uglify-js": "1.x",
-				"walker": "1.x",
-				"winston": "*",
-				"wrench": "1.3.x"
-			},
-			"engines": {
-				"node": ">v0.4.12"
-			}
-		},
-		"node_modules/build/node_modules/uglify-js": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-			"integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ==",
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			}
-		},
 		"node_modules/call-bind-apply-helpers": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2912,19 +2840,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/color": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
-			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^3.1.3",
-				"color-string": "^2.1.3"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2944,48 +2859,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/color-string": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
-			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/color-string/node_modules/color-name": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
-		"node_modules/color/node_modules/color-convert": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
-			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.6"
-			}
-		},
-		"node_modules/color/node_modules/color-name": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
-			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -3034,14 +2907,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/cssmin": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/cssmin/-/cssmin-0.3.2.tgz",
-			"integrity": "sha512-bynxGIAJ8ybrnFobjsQotIjA8HFDDgPwbeUWNXXXfR+B4f9kkxdcUyagJoQCSUOfMV+ZZ6bMn8bvbozlCzUGwQ==",
-			"bin": {
-				"cssmin": "bin/cssmin"
 			}
 		},
 		"node_modules/debug": {
@@ -3177,12 +3042,6 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/enabled": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
 			"license": "MIT"
 		},
 		"node_modules/error-ex": {
@@ -3382,12 +3241,6 @@
 				"bser": "2.1.1"
 			}
 		},
-		"node_modules/fecha": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"license": "MIT"
-		},
 		"node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3401,12 +3254,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/fn.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"license": "MIT"
 		},
 		"node_modules/follow-redirects": {
 			"version": "1.16.0",
@@ -3783,6 +3630,7 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/is-arrayish": {
@@ -3816,6 +3664,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4691,6 +4540,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
 			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4722,18 +4572,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jsmin": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/jsmin/-/jsmin-1.0.1.tgz",
-			"integrity": "sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==",
-			"license": "Doug Crockford's license that allows this module to be used for Good but not for Evil",
-			"bin": {
-				"jsmin": "bin/jsmin"
-			},
-			"engines": {
-				"node": ">=0.1.93"
-			}
-		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -4753,26 +4591,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/jxLoader": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jxLoader/-/jxLoader-0.1.1.tgz",
-			"integrity": "sha512-ClEvAj3K68y8uKhub3RgTmcRPo5DfIWvtxqrKQdDPyZ1UVHIIKvVvjrAsJFSVL5wjv0rt5iH9SMCZ0XRKNzeUA==",
-			"dependencies": {
-				"js-yaml": "0.3.x",
-				"moo-server": "1.3.x",
-				"promised-io": "*",
-				"walker": "1.x"
-			},
-			"engines": {
-				"node": ">v0.4.10"
-			}
-		},
-		"node_modules/kuler": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"license": "MIT"
 		},
 		"node_modules/langsmith": {
 			"version": "0.7.2",
@@ -4845,23 +4663,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/logform": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
-			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@colors/colors": "1.6.0",
-				"@types/triple-beam": "^1.3.2",
-				"fecha": "^4.2.0",
-				"ms": "^2.1.1",
-				"safe-stable-stringify": "^2.3.1",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4912,6 +4713,7 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
 			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tmpl": "1.0.5"
@@ -5000,18 +4802,11 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/moo-server": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/moo-server/-/moo-server-1.3.0.tgz",
-			"integrity": "sha512-9A8/eor2DXwpv1+a4pZAAydqLFVrWoKoO1fzdzqLUhYVXAO1Kgd1FR2gFZi7YdHzF0s4W8cDNwCfKJQrvLqxDw==",
-			"engines": {
-				"node": ">v0.4.10"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mustache": {
@@ -5102,15 +4897,6 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
-			}
-		},
-		"node_modules/one-time": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
-			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-			"license": "MIT",
-			"dependencies": {
-				"fn.name": "1.x.x"
 			}
 		},
 		"node_modules/onetime": {
@@ -5376,11 +5162,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/promised-io": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.6.tgz",
-			"integrity": "sha512-bNwZusuNIW4m0SPR8jooSyndD35ggirHlxVl/UhIaZD/F0OBv9ebfc6tNmbpZts3QXHggkjIBH8lvtnzhtcz0A=="
-		},
 		"node_modules/proxy-from-env": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -5424,20 +5205,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5469,35 +5236,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/safe-stable-stringify": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-			"integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/semver": {
@@ -5571,15 +5309,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/stack-trace": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -5591,15 +5320,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
 			}
 		},
 		"node_modules/string-length": {
@@ -5751,34 +5471,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-hex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"license": "MIT"
-		},
-		"node_modules/timespan": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
-			"integrity": "sha512-0Jq9+58T2wbOyLth0EU+AUb6JMGCLaTWIykJFa7hyAybjVH9gpVMTfUAwo5fWAvtFt2Tjh/Elg8JtgNpnMnM8g==",
-			"engines": {
-				"node": ">= 0.2.0"
-			}
-		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true,
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/triple-beam": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
-			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 14.0.0"
-			}
 		},
 		"node_modules/ts-jest": {
 			"version": "29.4.11",
@@ -6038,12 +5736,6 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
-		"node_modules/util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"license": "MIT"
-		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -6081,6 +5773,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
 			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"makeerror": "1.0.12"
@@ -6100,42 +5793,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/winston": {
-			"version": "3.19.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
-			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
-			"license": "MIT",
-			"dependencies": {
-				"@colors/colors": "^1.6.0",
-				"@dabh/diagnostics": "^2.0.8",
-				"async": "^3.2.3",
-				"is-stream": "^2.0.0",
-				"logform": "^2.7.0",
-				"one-time": "^1.0.0",
-				"readable-stream": "^3.4.0",
-				"safe-stable-stringify": "^2.3.1",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.9.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
-			}
-		},
-		"node_modules/winston-transport": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
-			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
-			"license": "MIT",
-			"dependencies": {
-				"logform": "^2.7.0",
-				"readable-stream": "^3.6.2",
-				"triple-beam": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/wordwrap": {
@@ -6188,15 +5845,6 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/wrench": {
-			"version": "1.3.9",
-			"resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
-			"integrity": "sha512-srTJQmLTP5YtW+F5zDuqjMEZqLLr/eJOZfDI5ibfPfRMeDh3oBUefAscuH0q5wBKE339ptH/S/0D18ZkfOfmKQ==",
-			"deprecated": "wrench.js is deprecated! You should check out fs-extra (https://github.com/jprichardson/node-fs-extra) for any operations you were using wrench for. Thanks for all the usage over the years.",
-			"engines": {
-				"node": ">=0.1.97"
-			}
 		},
 		"node_modules/write-file-atomic": {
 			"version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,5 @@
 	},
 	"engines": {
 		"node": ">=18.0.0"
-	},
-	"dependencies": {
-		"build": "^0.1.4"
 	}
 }


### PR DESCRIPTION
Removes the unused `build@0.1.4` runtime dependency, which was the sole source of 3 open Dependabot alerts (all transitive):

  - #58 — critical: uglify-js < 2.4.24
  - #57 — high: uglify-js < 2.6.0
  - #59 — high: timespan ReDoS (no patch available)

  `build` is an abandoned 2013 npm package and was never imported anywhere in `src/`, `api.ts`, or tests. Real build tooling is `esbuild` + `tsc` (already in
  devDependencies). Also prunes 35 stale transitive packages from the lockfile.